### PR TITLE
feat(pastebin): add D1-backed pastebin with Google OAuth, delete support, and robust viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,29 @@ A minimal Cloudflare Worker that serves a small suite of browser tools.
 
 Both tools include a Home button in the header to return to `/`.
 
+- Pastebin (`/pastebin`)
+  - Create and share text snippets.
+  - Visibility options: `public` (listed) or `unlisted` (hidden from lists, accessible by link).
+  - Auth via Google OAuth; stores users, sessions, and pastes in Cloudflare D1.
+  - Public listing at `/pastebin` shows recent public pastes; your pastes appear after sign-in.
+  - Direct links like `/pastebin/p/abcd1234` open a read-only view.
+
 ## Routes
 - `/` — Tools index page with tiles.
 - `/markdown` — Markdown Preview.
 - `/euler` — Euler Preview (Project Euler forum flavor).
+ - `/pastebin` — Pastebin UI (create, list, login).
+ - `/pastebin/p/:id` — View a specific paste (public or unlisted).
+ - API: `/api/pastebin/*`, `/api/auth/*`, OAuth: `/auth/google/*`.
 
 ## Project Structure
 - `src/index.ts` — Worker entry; routes and serves static assets from `public` via the `ASSETS` binding. Falls back to bundled reads in tests/dev.
 - `public/index.html` — Index page.
 - `public/markdown.html` — Markdown Preview page (Marked + DOMPurify + MathJax, tabs, Highlight.js with theme swap, copy button).
 - `public/euler.html` — Euler Preview page (BBCode → HTML, MathJax, tabs, Highlight.js with theme swap).
+ - `public/pastebin.html` — Pastebin UI.
 - `wrangler.jsonc` — Wrangler config with assets binding enabled.
+ - `migrations/0001_pastebin.sql` — D1 tables for users, sessions, pastes.
 - `test/index.spec.ts` — Basic unit/integration tests.
 
 ## Development
@@ -42,10 +54,27 @@ Both tools include a Home button in the header to return to `/`.
 
 If you change static HTML in `public/`, no Worker code changes are required.
 
+## Pastebin Setup
+1. Create a D1 database and bind it:
+   - In `wrangler.jsonc`, set `d1_databases[0].database_id` to your D1 id (or use an env binding).
+   - Run migrations: `wrangler d1 migrations apply web_tools_db` (or your database name).
+2. Configure Google OAuth:
+   - Create OAuth 2.0 Client (Web) in Google Cloud Console.
+   - Authorized redirect URI: `https://YOUR_DOMAIN/auth/google/callback`
+   - Set vars/secrets:
+     - `wrangler secret put GOOGLE_CLIENT_SECRET`
+     - `wrangler kv:namespace` not required.
+     - In `wrangler.jsonc` `vars`, set `GOOGLE_CLIENT_ID` and `OAUTH_REDIRECT_URL`.
+     - Optional: `SESSION_COOKIE_NAME` (defaults to `wt_session`).
+3. Dev: ensure your dev URL’s redirect matches (use `--local-protocol=https` or a tunnel if needed).
+
+Security notes:
+- Sessions use random tokens stored in D1 and set as HttpOnly, Secure, SameSite=Lax cookies.
+- Only `public` pastes appear in listings; `unlisted` require the direct link.
+
 ## Notes
 - MathJax inline delimiters are restricted to `$...$` to avoid conflicts with literal parentheses in text and links; display math supports `$$...$$` and `\[...\]`.
 - Output HTML is sanitized before insertion. Be cautious if you change the sanitization step.
 
 ## License
 MIT — see [LICENSE.md](LICENSE.md).
-

--- a/migrations/0001_pastebin.sql
+++ b/migrations/0001_pastebin.sql
@@ -1,0 +1,33 @@
+-- D1 schema for Pastebin tool
+-- Users come from Google OAuth; we key by Google sub (string)
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY, -- google sub
+  email TEXT,
+  name TEXT,
+  picture TEXT,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+-- Sessions map random token -> user id
+CREATE TABLE IF NOT EXISTS sessions (
+  token TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  expires_at TEXT,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);
+
+-- Pastes
+CREATE TABLE IF NOT EXISTS pastes (
+  id TEXT PRIMARY KEY, -- slug
+  user_id TEXT NOT NULL,
+  title TEXT,
+  content TEXT NOT NULL,
+  visibility TEXT NOT NULL CHECK (visibility IN ('public','unlisted')),
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+CREATE INDEX IF NOT EXISTS idx_pastes_visibility_created ON pastes(visibility, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_pastes_user_created ON pastes(user_id, created_at DESC);
+

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,10 @@
         <h2>Euler Preview</h2>
         <p>Preview Project Euler forum posts (BBCode + TeX).</p>
       </a>
+      <a class="tile" href="/pastebin">
+        <h2>Pastebin</h2>
+        <p>Share text snippets; public or unlisted links.</p>
+      </a>
     </main>
     <footer>More tools coming soon.</footer>
   </body>

--- a/public/pastebin.html
+++ b/public/pastebin.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Pastebin</title>
+    <style>
+      :root { color-scheme: light dark; }
+      * { box-sizing: border-box; }
+      html, body { height: 100%; margin: 0; }
+      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, sans-serif; }
+      header { display: flex; gap: 8px; align-items: center; justify-content: space-between; padding: .75rem 1rem; border-bottom: 1px solid #ddd; }
+      h1 { margin: 0; font-size: 1.15rem; }
+      main { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; padding: 12px; }
+      .panel { border: 1px solid #ddd; border-radius: 8px; overflow: hidden; display: flex; flex-direction: column; }
+      .panel header { border-bottom: 1px solid #ddd; padding: .5rem .75rem; }
+      .panel .content { padding: .75rem; display: flex; gap: 8px; flex-direction: column; }
+      textarea { width: 100%; min-height: 220px; resize: vertical; padding: .75rem; border: 1px solid #ccc; border-radius: 8px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 14px; }
+      input, select, button { font: inherit; padding: .5rem .6rem; border-radius: 8px; border: 1px solid #ccc; }
+      .row { display: flex; gap: 8px; align-items: center; }
+      .grow { flex: 1; }
+      .muted { color: #777; font-size: .9rem; }
+      .list { padding: .5rem; max-height: 420px; overflow: auto; }
+      .list-item { display: flex; justify-content: space-between; align-items: center; padding: .5rem; border-bottom: 1px solid #eee; gap: 8px; }
+      .list-item a { text-decoration: none; }
+      .pill { font-size: .75rem; border: 1px solid #bbb; border-radius: 999px; padding: .15rem .5rem; }
+      .right { margin-left: auto; }
+      .btn-danger { background:#d9534f; border-color:#d43f3a; color:white }
+      @media (max-width: 1000px) { main { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Pastebin</h1>
+      <div id="authArea" class="row"></div>
+    </header>
+    <main>
+      <section id="viewPanel" class="panel" style="display:none">
+        <header><strong>View Paste</strong></header>
+        <div class="content">
+          <div class="row"><input id="vtitle" class="grow" readonly /></div>
+          <textarea id="vcontent" readonly></textarea>
+          <div class="row" style="justify-content: space-between; align-items: center;">
+            <div class="muted" id="vmeta"></div>
+            <button id="deleteBtn" style="display:none; background:#d9534f; border-color:#d43f3a; color:white">Delete</button>
+          </div>
+          <div class="muted" id="verror" style="display:none"></div>
+        </div>
+      </section>
+      <section class="panel">
+        <header><strong>Create Paste</strong></header>
+        <div class="content">
+          <input id="title" class="grow" placeholder="Title (optional)" />
+          <textarea id="content" placeholder="Paste text here..."></textarea>
+          <div class="row">
+            <label for="visibility">Visibility</label>
+            <select id="visibility">
+              <option value="public">Public</option>
+              <option value="unlisted">Unlisted</option>
+            </select>
+            <button id="createBtn" class="right">Create</button>
+          </div>
+          <div id="createResult" class="muted"></div>
+        </div>
+      </section>
+      <section class="panel">
+        <header><strong>Your Pastes</strong></header>
+        <div class="list" id="mineList"><div class="muted">Sign in to see your pastes.</div></div>
+        <header><strong>Recent Public</strong></header>
+        <div class="list" id="publicList"><div class="muted">Loading…</div></div>
+      </section>
+    </main>
+    <script>
+      const qs = (sel) => document.querySelector(sel);
+      async function api(path, opts={}) {
+        const res = await fetch(path, Object.assign({credentials:'include'}, opts));
+        if (!res.ok) throw new Error(await res.text());
+        return res.json();
+      }
+      function el(tag, attrs={}, children=[]) { const e = document.createElement(tag); Object.entries(attrs).forEach(([k,v])=>{ if(k==='class') e.className=v; else if(k==='href'||k==='target'||k==='rel') e.setAttribute(k,v); else e[k]=v; }); children.forEach(c=> e.appendChild(typeof c==='string'?document.createTextNode(c):c)); return e; }
+
+      async function refreshAuth() {
+        try {
+          const me = await api('/api/auth/me');
+          if (me.loggedIn) {
+            qs('#authArea').innerHTML = '';
+            qs('#authArea').append(
+              el('span', { class: 'muted' }, [me.user.email]),
+              el('button', { onclick: async()=>{ await api('/api/auth/logout', { method: 'POST' }); location.reload(); } }, ['Logout'])
+            );
+            loadMine();
+          } else {
+            qs('#authArea').innerHTML = '';
+            qs('#authArea').append(
+              el('a', { href: '/auth/google/login' }, ['Login with Google'])
+            );
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      }
+
+      async function loadMine() {
+        try {
+          const data = await api('/api/pastebin/mine');
+          const list = qs('#mineList');
+          list.innerHTML = '';
+          if (!data || !data.length) { list.append(el('div', {class:'muted'}, ['No pastes yet.'])); return; }
+          data.forEach(p => {
+            const row = el('div', { class: 'list-item' }, []);
+            const link = el('a', { href: `/pastebin/p/${p.id}` }, [p.title || '(untitled)']);
+            const vis = el('span', { class: 'pill' }, [p.visibility]);
+            const del = el('button', { class: 'btn-danger', title: 'Delete paste' }, ['Delete']);
+            del.addEventListener('click', async (ev) => {
+              ev.preventDefault(); ev.stopPropagation();
+              if (!confirm('Delete this paste? This cannot be undone.')) return;
+              try {
+                await api('/api/pastebin/delete', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ id: p.id }) });
+                loadMine();
+                loadPublic();
+                const m = location.pathname.match(/\/pastebin\/p\/([A-Za-z0-9_-]+)/);
+                if (m && m[1] === p.id) location.href = '/pastebin';
+              } catch (e) {
+                alert('Failed to delete paste: ' + e.message);
+              }
+            });
+            row.append(link, vis, del);
+            list.append(row);
+          });
+        } catch (e) {
+          qs('#mineList').innerHTML = '<div class="muted">Sign in to see your pastes.</div>';
+        }
+      }
+
+      async function loadPublic() {
+        try {
+          const data = await api('/api/pastebin/public');
+          const list = qs('#publicList');
+          list.innerHTML = '';
+          if (!data || !data.length) { list.append(el('div', {class:'muted'}, ['No public pastes.'])); return; }
+          data.forEach(p => {
+            list.append(el('div', { class: 'list-item' }, [
+              el('a', { href: `/pastebin/p/${p.id}` }, [p.title || '(untitled)']),
+              el('span', { class: 'pill' }, [new Date(p.created_at).toLocaleString()])
+            ]));
+          });
+        } catch (e) {
+          qs('#publicList').innerHTML = '<div class="muted">Failed to load.</div>';
+        }
+      }
+
+      async function createPaste() {
+        const title = qs('#title').value.trim();
+        const content = qs('#content').value;
+        const visibility = qs('#visibility').value;
+        if (!content) { alert('Please enter content'); return; }
+        try {
+          const res = await api('/api/pastebin/create', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ title, content, visibility })
+          });
+          const url = `/pastebin/p/${res.id}`;
+          qs('#createResult').innerHTML = `Created: <a href="${url}">${url}</a>`;
+          loadMine();
+          if (visibility === 'public') loadPublic();
+        } catch (e) {
+          alert('Failed to create paste: ' + e.message);
+        }
+      }
+
+      qs('#createBtn').addEventListener('click', createPaste);
+      async function maybeView() {
+        const injected = window.PASTE_ID;
+        const m = !injected && location.pathname.match(/\/pastebin\/p\/([^\/?#]+)/);
+        const id = injected || (m ? m[1].replace(/\/$/, '') : (new URL(location.href)).searchParams.get('id'));
+        if (!id) return;
+        try {
+          const data = await api(`/api/pastebin/get?id=${encodeURIComponent(id)}`);
+          document.title = (data.title || 'Paste') + ' - Pastebin';
+          qs('#vtitle').value = data.title || '';
+          qs('#vcontent').value = data.content || '';
+          qs('#vmeta').textContent = `${data.visibility.toUpperCase()} • ${new Date(data.created_at).toLocaleString()}`;
+          qs('#viewPanel').style.display = '';
+          // De-emphasize create/list panels when viewing a specific paste
+          document.querySelectorAll('main > section.panel').forEach((s, idx) => { if (idx > 0) s.style.opacity = '0.6'; });
+          if (data.can_delete) {
+            const delBtn = qs('#deleteBtn');
+            delBtn.style.display = '';
+            delBtn.onclick = async () => {
+              if (!confirm('Delete this paste? This cannot be undone.')) return;
+              try {
+                await api('/api/pastebin/delete', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ id }) });
+                location.href = '/pastebin';
+              } catch (e) {
+                alert('Failed to delete paste: ' + e.message);
+              }
+            };
+          }
+          // Scroll to top to show the viewer first
+          window.scrollTo({ top: 0 });
+        } catch (e) {
+          console.error(e);
+          qs('#verror').style.display = '';
+          qs('#verror').textContent = 'Failed to load paste.';
+          qs('#viewPanel').style.display = '';
+        }
+      }
+
+      refreshAuth();
+      loadPublic();
+      maybeView();
+    </script>
+  </body>
+  </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,18 @@
 /**
- * Welcome to Cloudflare Workers! This is your first worker.
- *
- * - Run `npm run dev` in your terminal to start a development server
- * - Open a browser tab at http://localhost:8787/ to see your worker in action
- * - Run `npm run deploy` to publish your worker
- *
- * Bind resources to your worker in `wrangler.jsonc`. After adding bindings, a type definition for the
- * `Env` object can be regenerated with `npm run cf-typegen`.
- *
- * Learn more at https://developers.cloudflare.com/workers/
+ * Worker entry with static assets and a new /pastebin tool backed by D1.
+ * Google OAuth is used for accounts; pastes can be public or unlisted.
  */
+
 // HTML templates moved to /public and served via ASSETS binding.
+
+type Bindings = Env & {
+  DB: D1Database;
+  ASSETS: Fetcher;
+  GOOGLE_CLIENT_ID?: string;
+  GOOGLE_CLIENT_SECRET?: string; // set as secret via wrangler
+  OAUTH_REDIRECT_URL?: string;
+  SESSION_COOKIE_NAME?: string;
+};
 
 async function loadHtml(filename: string): Promise<Response> {
   const url = new URL(`../public/${filename}`, import.meta.url);
@@ -25,15 +27,237 @@ async function loadHtml(filename: string): Promise<Response> {
   });
 }
 
-// See public/markdown.html for the Markdown viewer page.
+function json(data: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(data), {
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    ...init,
+  });
+}
+
+function badRequest(message: string, status = 400): Response {
+  return new Response(message, { status });
+}
+
+function getCookies(req: Request): Record<string, string> {
+  const h = req.headers.get('cookie') || '';
+  const out: Record<string, string> = {};
+  h.split(/;\s*/).forEach((p) => {
+    if (!p) return;
+    const idx = p.indexOf('=');
+    if (idx === -1) return;
+    const k = decodeURIComponent(p.slice(0, idx).trim());
+    const v = decodeURIComponent(p.slice(idx + 1).trim());
+    out[k] = v;
+  });
+  return out;
+}
+
+function setCookie(res: Response, name: string, value: string, attrs: Record<string, string | number | boolean> = {}) {
+  const parts = [`${encodeURIComponent(name)}=${encodeURIComponent(value)}`];
+  if (attrs.path !== undefined) parts.push(`Path=${attrs.path}`);
+  if (attrs.httpOnly !== false) parts.push('HttpOnly');
+  if (attrs.sameSite !== undefined) parts.push(`SameSite=${attrs.sameSite}`);
+  if (attrs.secure !== false) parts.push('Secure');
+  if (attrs.maxAge !== undefined) parts.push(`Max-Age=${attrs.maxAge}`);
+  if (attrs.expires !== undefined) parts.push(`Expires=${attrs.expires}`);
+  // Important: append separate Set-Cookie headers; do not join with newlines
+  res.headers.append('Set-Cookie', parts.join('; '));
+}
+
+async function readJson<T = any>(req: Request): Promise<T> {
+  const ct = req.headers.get('content-type') || '';
+  if (ct.includes('application/json')) return await req.json<T>();
+  const text = await req.text();
+  try { return JSON.parse(text) as T; } catch { return {} as T; }
+}
+
+function urlSafeRandom(len = 12): string {
+  const bytes = new Uint8Array(len);
+  crypto.getRandomValues(bytes);
+  const alph = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let out = '';
+  for (let i = 0; i < len; i++) out += alph[bytes[i] % alph.length];
+  return out;
+}
+
+async function getSessionUser(req: Request, env: Bindings): Promise<{ id: string; email?: string; name?: string; picture?: string } | null> {
+  const cookieName = env.SESSION_COOKIE_NAME || 'wt_session';
+  const cookies = getCookies(req);
+  const token = cookies[cookieName];
+  if (!token) return null;
+  const row = await env.DB.prepare('SELECT u.id, u.email, u.name, u.picture FROM sessions s JOIN users u ON u.id = s.user_id WHERE s.token = ?').bind(token).first();
+  if (!row) return null;
+  return row as any;
+}
+
+async function requireUser(req: Request, env: Bindings): Promise<{ id: string; email?: string } | Response> {
+  const user = await getSessionUser(req, env);
+  if (!user) return new Response('Unauthorized', { status: 401 });
+  return user;
+}
 
 export default {
   async fetch(request, env, _ctx): Promise<Response> {
+    const b = env as unknown as Bindings;
     const url = new URL(request.url);
     let path = url.pathname;
+
+    // -------- Auth API --------
+    if (path === '/api/auth/me' && request.method === 'GET') {
+      const user = await getSessionUser(request, b);
+      return json({ loggedIn: !!user, user });
+    }
+    if (path === '/api/auth/logout' && request.method === 'POST') {
+      const cookieName = b.SESSION_COOKIE_NAME || 'wt_session';
+      const token = getCookies(request)[cookieName];
+      if (token) await b.DB.prepare('DELETE FROM sessions WHERE token = ?').bind(token).run();
+      const res = json({ ok: true });
+      setCookie(res, cookieName, '', { path: '/', maxAge: 0, httpOnly: true, secure: true, sameSite: 'Lax' });
+      return res;
+    }
+    if (path === '/auth/google/login' && request.method === 'GET') {
+      const clientId = b.GOOGLE_CLIENT_ID;
+      const redirect = b.OAUTH_REDIRECT_URL;
+      if (!clientId || !redirect) return badRequest('Google OAuth not configured', 500);
+      const state = urlSafeRandom(16);
+      const oauthUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+      oauthUrl.searchParams.set('client_id', clientId);
+      oauthUrl.searchParams.set('redirect_uri', redirect);
+      oauthUrl.searchParams.set('response_type', 'code');
+      oauthUrl.searchParams.set('scope', 'openid email profile');
+      oauthUrl.searchParams.set('state', state);
+      const res = new Response(null, { status: 302, headers: { location: oauthUrl.toString() } });
+      setCookie(res, 'oauth_state', state, { path: '/', httpOnly: true, secure: true, sameSite: 'Lax', maxAge: 600 });
+      return res;
+    }
+    if (path === '/auth/google/callback' && request.method === 'GET') {
+      const state = url.searchParams.get('state') || '';
+      const code = url.searchParams.get('code') || '';
+      const cookieState = getCookies(request)['oauth_state'];
+      if (!code || !state || !cookieState || state !== cookieState) return badRequest('Invalid state');
+      const clientId = b.GOOGLE_CLIENT_ID || '';
+      const clientSecret = (b as any).GOOGLE_CLIENT_SECRET as string | undefined;
+      const redirect = b.OAUTH_REDIRECT_URL || '';
+      if (!clientId || !clientSecret || !redirect) return badRequest('OAuth not configured', 500);
+      const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          code,
+          client_id: clientId,
+          client_secret: clientSecret,
+          redirect_uri: redirect,
+          grant_type: 'authorization_code',
+        }),
+      });
+      if (!tokenRes.ok) return badRequest('Token exchange failed', 500);
+      const tokenJson = await tokenRes.json<any>();
+      const accessToken = tokenJson.access_token as string;
+      if (!accessToken) return badRequest('No access token', 500);
+      const infoRes = await fetch('https://openidconnect.googleapis.com/v1/userinfo', {
+        headers: { authorization: `Bearer ${accessToken}` },
+      });
+      if (!infoRes.ok) return badRequest('Failed to fetch userinfo', 500);
+      const info = await infoRes.json<any>();
+      const sub = String(info.sub);
+      const email = String(info.email || '');
+      const name = String(info.name || '');
+      const picture = String(info.picture || '');
+      await b.DB.prepare('INSERT INTO users (id, email, name, picture) VALUES (?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET email=excluded.email, name=excluded.name, picture=excluded.picture')
+        .bind(sub, email, name, picture)
+        .run();
+      const token = urlSafeRandom(24);
+      const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7).toUTCString();
+      await b.DB.prepare('INSERT INTO sessions (token, user_id, expires_at) VALUES (?, ?, ?)').bind(token, sub, expiresAt).run();
+      const res = new Response(null, { status: 302, headers: { location: '/pastebin' } });
+      setCookie(res, 'oauth_state', '', { path: '/', maxAge: 0 });
+      setCookie(res, b.SESSION_COOKIE_NAME || 'wt_session', token, { path: '/', httpOnly: true, secure: true, sameSite: 'Lax', maxAge: 60 * 60 * 24 * 7 });
+      return res;
+    }
+
+    // -------- Pastebin API --------
+    if (path === '/api/pastebin/create' && request.method === 'POST') {
+      const user = await requireUser(request, b);
+      if (user instanceof Response) return user;
+      const body = await readJson<{ title?: string; content?: string; visibility?: 'public' | 'unlisted' }>(request);
+      const content = (body.content || '').toString();
+      const title = (body.title || '').toString().slice(0, 200);
+      const visibility = (body.visibility === 'unlisted' ? 'unlisted' : 'public') as 'public' | 'unlisted';
+      if (!content) return badRequest('content required');
+      for (let i = 0; i < 5; i++) {
+        const slug = visibility === 'public' ? urlSafeRandom(8) : urlSafeRandom(14);
+        const exists = await b.DB.prepare('SELECT id FROM pastes WHERE id = ?').bind(slug).first();
+        if (exists) continue;
+        await b.DB.prepare('INSERT INTO pastes (id, user_id, title, content, visibility) VALUES (?, ?, ?, ?, ?)')
+          .bind(slug, (user as any).id, title, content, visibility)
+          .run();
+        return json({ id: slug });
+      }
+      return badRequest('Failed to allocate id', 500);
+    }
+    if (path === '/api/pastebin/mine' && request.method === 'GET') {
+      const user = await requireUser(request, b);
+      if (user instanceof Response) return user;
+      const rows = await b.DB.prepare('SELECT id, title, visibility, created_at FROM pastes WHERE user_id = ? ORDER BY created_at DESC LIMIT 200').bind((user as any).id).all();
+      return json(rows.results || []);
+    }
+    if (path === '/api/pastebin/public' && request.method === 'GET') {
+      const rows = await b.DB.prepare("SELECT id, title, visibility, created_at FROM pastes WHERE visibility = 'public' ORDER BY created_at DESC LIMIT 200").all();
+      return json(rows.results || []);
+    }
+    if (path === '/api/pastebin/get' && request.method === 'GET') {
+      const id = url.searchParams.get('id') || '';
+      if (!id) return badRequest('id required');
+      const row = (await b.DB.prepare('SELECT id, user_id, title, content, visibility, created_at FROM pastes WHERE id = ?').bind(id).first()) as any;
+      if (!row) return new Response('Not found', { status: 404 });
+      const me = await getSessionUser(request, b);
+      const can_delete = !!(me && me.id === row.user_id);
+      const { user_id, ...rest } = row;
+      return json({ ...rest, can_delete });
+    }
+    if (path === '/api/pastebin/delete' && request.method === 'POST') {
+      const user = await requireUser(request, b);
+      if (user instanceof Response) return user;
+      const body = await readJson<{ id?: string }>(request);
+      const id = (body.id || '').toString();
+      if (!id) return badRequest('id required');
+      const row = (await b.DB.prepare('SELECT user_id FROM pastes WHERE id = ?').bind(id).first()) as any;
+      if (!row) return new Response('Not found', { status: 404 });
+      if (row.user_id !== (user as any).id) return new Response('Forbidden', { status: 403 });
+      await b.DB.prepare('DELETE FROM pastes WHERE id = ?').bind(id).run();
+      return json({ ok: true });
+    }
+
+    // -------- Static/HTML routing --------
     if (path === '/' || path === '') path = '/index.html';
     else if (path === '/markdown' || path === '/markdown/') path = '/markdown.html';
     else if (path === '/euler' || path === '/euler/') path = '/euler.html';
+    else if (path === '/pastebin' || path === '/pastebin/') path = '/pastebin.html';
+    else if (path.startsWith('/pastebin/p/')) {
+      // Serve pastebin page with the ID injected for robust client rendering
+      const id = path.replace(/^\/pastebin\/p\//, '').replace(/\/$/, '');
+      // Try assets binding first
+      const assetUrl = new URL(url);
+      assetUrl.pathname = '/pastebin.html';
+      const assetRequest = new Request(assetUrl.toString(), request);
+      const assets = (env as any)?.ASSETS;
+      let html: string | null = null;
+      if (assets && typeof assets.fetch === 'function') {
+        const res = await assets.fetch(assetRequest);
+        if (res && res.status !== 404) {
+          html = await res.text();
+        }
+      }
+      if (!html) {
+        // If the asset binding isn't available, redirect to absolute /pastebin?id=... so client can fetch.
+        const redirectUrl = new URL(request.url);
+        redirectUrl.pathname = '/pastebin';
+        redirectUrl.search = `?id=${encodeURIComponent(id)}`;
+        return Response.redirect(redirectUrl.toString(), 302);
+      }
+      const injected = html.replace('</body>', `<script>window.PASTE_ID=${JSON.stringify(id)};<\/script></body>`);
+      return new Response(injected, { headers: { 'content-type': 'text/html; charset=utf-8' } });
+    }
 
     const assetUrl = new URL(url);
     assetUrl.pathname = path;
@@ -48,6 +272,7 @@ export default {
     // Fallback to bundled HTML (tests/dev) if assets binding unavailable
     if (path.endsWith('markdown.html')) return loadHtml('markdown.html');
     if (path.endsWith('euler.html')) return loadHtml('euler.html');
+    if (path.endsWith('pastebin.html')) return loadHtml('pastebin.html');
     if (path.endsWith('index.html')) return loadHtml('index.html');
 
     return new Response('Not found', { status: 404 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -35,6 +35,18 @@
 	 * https://developers.cloudflare.com/workers/static-assets/binding/
 	 */
 	"assets": { "directory": "./public/", "binding": "ASSETS" },
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "web_tools_db",
+			"database_id": "f09d1fa6-3f91-4679-ae32-78c588c1e0bb"
+		}
+	],
+	"vars": {
+		"OAUTH_REDIRECT_URL": "https://web-tools.bruce-hart.workers.dev/auth/google/callback",
+		"GOOGLE_CLIENT_ID": "23831454371-uqiege2i9k1bg9qnktbnhdlccm5pi934.apps.googleusercontent.com",
+		"SESSION_COOKIE_NAME": "wt_session"
+	}
 	/**
 	 * Service Bindings (communicate between multiple Workers)
 	 * https://developers.cloudflare.com/workers/wrangler/configuration/#service-bindings


### PR DESCRIPTION
- Add Pastebin tool UI at public/pastebin.html; create pastes with public/unlisted visibility, list user pastes, list recent public
- Add server API endpoints in src/index.ts:
  - Auth: /api/auth/me, /api/auth/logout, /auth/google/login, /auth/google/callback (Google OAuth 2.0, stores sessions in D1)
  - Pastebin: /api/pastebin/create, /api/pastebin/mine, /api/pastebin/public, /api/pastebin/get, /api/pastebin/delete
- Implement sessions with secure HttpOnly cookies; fix Set-Cookie header handling (append separate headers, no newlines)
- Support viewing /pastebin/p/:id by injecting window.PASTE_ID when serving pastebin.html via ASSETS; fallback to absolute redirect to /pastebin?id=:id when assets unavailable
- Improve client viewer logic to read injected ID or query id; show Delete button for owner; show inline errors
- Add migrations/0001_pastebin.sql with users, sessions, pastes tables and indexes
- Update public/index.html to link Pastebin; update README with routes, setup instructions, and security notes
- Update wrangler.jsonc with D1 binding (DB) and vars for OAuth + session cookie