### PR TITLE
Fix pastebin persistence: use D1 for logged-in users; load lists reliably

### DIFF
--- a/public/pastebin.html
+++ b/public/pastebin.html
@@ -136,14 +136,8 @@
               el('span', { class: 'muted' }, [me.user.email]),
               el('button', { onclick: async()=>{ await api('/api/auth/logout', { method: 'POST' }); location.reload(); } }, ['Logout'])
             );
-            if (me.allowed) {
-              loadMine();
-            } else {
-              const list = qs('#mineList');
-              if (list) list.innerHTML = '';
-              renderLocalMine();
-              qs('#createResult').textContent = 'Not allowed to save on server; creating local pastes.';
-            }
+            // Any logged-in user stores in server DB
+            loadMine();
           } else {
             qs('#authArea').innerHTML = '';
             qs('#authArea').append(
@@ -236,7 +230,7 @@
         const content = qs('#content').value;
         const visibility = qs('#visibility').value;
         if (!content) { alert('Please enter content'); return; }
-        if (window.PB_STATE && window.PB_STATE.allowed) {
+        if (PB_STATE && PB_STATE.loggedIn) {
           try {
             const res = await api('/api/pastebin/create', {
               method: 'POST',

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ export default {
 
     // -------- Pastebin API --------
     if (path === '/api/pastebin/create' && request.method === 'POST') {
-      const user = await requireAllowedUser(request, b);
+      const user = await requireUser(request, b);
       if (user instanceof Response) return user;
       const body = await readJson<{ title?: string; content?: string; visibility?: 'public' | 'unlisted' | 'private' }>(request);
       const content = (body.content || '').toString();
@@ -211,7 +211,7 @@ export default {
       return badRequest('Failed to allocate id', 500);
     }
     if (path === '/api/pastebin/mine' && request.method === 'GET') {
-      const user = await requireAllowedUser(request, b);
+      const user = await requireUser(request, b);
       if (user instanceof Response) return user;
       const rows = await b.DB.prepare('SELECT id, title, visibility, created_at FROM pastes WHERE user_id = ? ORDER BY created_at DESC LIMIT 200').bind((user as any).id).all();
       return json(rows.results || []);
@@ -234,7 +234,7 @@ export default {
       return json({ ...rest, can_delete });
     }
     if (path === '/api/pastebin/delete' && request.method === 'POST') {
-      const user = await requireAllowedUser(request, b);
+      const user = await requireUser(request, b);
       if (user instanceof Response) return user;
       const body = await readJson<{ id?: string }>(request);
       const id = (body.id || '').toString();


### PR DESCRIPTION
This PR fixes pastebin storage and listing behavior.\n\nChanges:\n- Backend: use `requireUser` for create/mine/delete so any authenticated user can persist to D1.\n- Frontend: gate create on `PB_STATE.loggedIn`, always call `loadMine()` when logged in, and avoid referencing `window.PB_STATE`.\n\nResults:\n- Signed-in users’ pastes are stored in D1.\n- "Your Pastes" loads immediately on page load when signed in.\n- Public list updates after creates/deletes.\n\nSchema reference (unchanged):\n\nCREATE TABLE "pastes" (\n  id TEXT PRIMARY KEY, -- slug\n  user_id TEXT NOT NULL,\n  title TEXT,\n  content TEXT NOT NULL,\n  visibility TEXT NOT NULL CHECK (visibility IN ('public','unlisted','private')),\n  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),\n  FOREIGN KEY (user_id) REFERENCES users(id)\n)\n\nCloses: pastebin persistence to local-only and initial empty list issues.