### PR TITLE
Add todo list tool with D1-backed API

### DIFF
--- a/migrations/0002_add_private_visibility.sql
+++ b/migrations/0002_add_private_visibility.sql
@@ -1,5 +1,4 @@
 -- Add 'private' visibility to pastes by recreating table with updated CHECK
-BEGIN TRANSACTION;
 
 -- Create new table with updated CHECK constraint
 CREATE TABLE IF NOT EXISTS pastes_new (
@@ -27,6 +26,3 @@ ALTER TABLE pastes_new RENAME TO pastes;
 -- Recreate indexes
 CREATE INDEX IF NOT EXISTS idx_pastes_visibility_created ON pastes(visibility, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_pastes_user_created ON pastes(user_id, created_at DESC);
-
-COMMIT;
-

--- a/migrations/0003_todo.sql
+++ b/migrations/0003_todo.sql
@@ -1,0 +1,19 @@
+-- D1 schema for To-Do List tool
+-- Uses existing users and sessions tables from 0001_pastebin.sql
+
+CREATE TABLE IF NOT EXISTS todos (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  completed INTEGER NOT NULL DEFAULT 0,
+  priority TEXT NOT NULL CHECK (priority IN ('low','medium','high')) DEFAULT 'medium',
+  due_date TEXT,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_todos_user_created ON todos(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_todos_user_completed ON todos(user_id, completed);
+CREATE INDEX IF NOT EXISTS idx_todos_user_priority ON todos(user_id, priority);

--- a/migrations/0004_todo_categories.sql
+++ b/migrations/0004_todo_categories.sql
@@ -1,0 +1,5 @@
+-- Add category column to todos table
+ALTER TABLE todos ADD COLUMN category TEXT DEFAULT 'personal';
+
+-- Create index for category filtering
+CREATE INDEX IF NOT EXISTS idx_todos_user_category ON todos(user_id, category);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@cloudflare/vitest-pool-workers": "^0.8.19",
 				"typescript": "^5.5.2",
 				"vitest": "~3.2.0",
-				"wrangler": "^4.37.1"
+				"wrangler": "^4.54.0"
 			}
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
@@ -676,9 +676,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-			"integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+			"integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -693,9 +693,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-			"integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+			"integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
 			"cpu": [
 				"arm"
 			],
@@ -710,9 +710,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-			"integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+			"integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
 			"cpu": [
 				"arm64"
 			],
@@ -727,9 +727,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-			"integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+			"integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
 			"cpu": [
 				"x64"
 			],
@@ -744,9 +744,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-			"integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+			"integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
 			"cpu": [
 				"arm64"
 			],
@@ -761,9 +761,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-			"integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+			"integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
 			"cpu": [
 				"x64"
 			],
@@ -778,9 +778,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-			"integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
 			"cpu": [
 				"arm64"
 			],
@@ -795,9 +795,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-			"integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+			"integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
 			"cpu": [
 				"x64"
 			],
@@ -812,9 +812,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-			"integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+			"integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
 			"cpu": [
 				"arm"
 			],
@@ -829,9 +829,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-			"integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+			"integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
 			"cpu": [
 				"arm64"
 			],
@@ -846,9 +846,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-			"integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+			"integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
 			"cpu": [
 				"ia32"
 			],
@@ -863,9 +863,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-			"integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+			"integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
 			"cpu": [
 				"loong64"
 			],
@@ -880,9 +880,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-			"integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+			"integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
 			"cpu": [
 				"mips64el"
 			],
@@ -897,9 +897,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-			"integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+			"integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -914,9 +914,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-			"integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+			"integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -931,9 +931,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-			"integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+			"integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
 			"cpu": [
 				"s390x"
 			],
@@ -948,9 +948,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-			"integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+			"integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
 			"cpu": [
 				"x64"
 			],
@@ -965,9 +965,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
-			"integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
 			"cpu": [
 				"arm64"
 			],
@@ -982,9 +982,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-			"integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
 			"cpu": [
 				"x64"
 			],
@@ -999,9 +999,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-			"integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1016,9 +1016,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-			"integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
 			"cpu": [
 				"x64"
 			],
@@ -1033,9 +1033,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
-			"integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+			"integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
 			"cpu": [
 				"arm64"
 			],
@@ -1050,9 +1050,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-			"integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+			"integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
 			"cpu": [
 				"x64"
 			],
@@ -1067,9 +1067,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-			"integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+			"integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1084,9 +1084,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-			"integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+			"integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1101,9 +1101,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-			"integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+			"integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
 			"cpu": [
 				"x64"
 			],
@@ -2212,9 +2212,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-			"integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+			"integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -2225,32 +2225,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.9",
-				"@esbuild/android-arm": "0.25.9",
-				"@esbuild/android-arm64": "0.25.9",
-				"@esbuild/android-x64": "0.25.9",
-				"@esbuild/darwin-arm64": "0.25.9",
-				"@esbuild/darwin-x64": "0.25.9",
-				"@esbuild/freebsd-arm64": "0.25.9",
-				"@esbuild/freebsd-x64": "0.25.9",
-				"@esbuild/linux-arm": "0.25.9",
-				"@esbuild/linux-arm64": "0.25.9",
-				"@esbuild/linux-ia32": "0.25.9",
-				"@esbuild/linux-loong64": "0.25.9",
-				"@esbuild/linux-mips64el": "0.25.9",
-				"@esbuild/linux-ppc64": "0.25.9",
-				"@esbuild/linux-riscv64": "0.25.9",
-				"@esbuild/linux-s390x": "0.25.9",
-				"@esbuild/linux-x64": "0.25.9",
-				"@esbuild/netbsd-arm64": "0.25.9",
-				"@esbuild/netbsd-x64": "0.25.9",
-				"@esbuild/openbsd-arm64": "0.25.9",
-				"@esbuild/openbsd-x64": "0.25.9",
-				"@esbuild/openharmony-arm64": "0.25.9",
-				"@esbuild/sunos-x64": "0.25.9",
-				"@esbuild/win32-arm64": "0.25.9",
-				"@esbuild/win32-ia32": "0.25.9",
-				"@esbuild/win32-x64": "0.25.9"
+				"@esbuild/aix-ppc64": "0.27.2",
+				"@esbuild/android-arm": "0.27.2",
+				"@esbuild/android-arm64": "0.27.2",
+				"@esbuild/android-x64": "0.27.2",
+				"@esbuild/darwin-arm64": "0.27.2",
+				"@esbuild/darwin-x64": "0.27.2",
+				"@esbuild/freebsd-arm64": "0.27.2",
+				"@esbuild/freebsd-x64": "0.27.2",
+				"@esbuild/linux-arm": "0.27.2",
+				"@esbuild/linux-arm64": "0.27.2",
+				"@esbuild/linux-ia32": "0.27.2",
+				"@esbuild/linux-loong64": "0.27.2",
+				"@esbuild/linux-mips64el": "0.27.2",
+				"@esbuild/linux-ppc64": "0.27.2",
+				"@esbuild/linux-riscv64": "0.27.2",
+				"@esbuild/linux-s390x": "0.27.2",
+				"@esbuild/linux-x64": "0.27.2",
+				"@esbuild/netbsd-arm64": "0.27.2",
+				"@esbuild/netbsd-x64": "0.27.2",
+				"@esbuild/openbsd-arm64": "0.27.2",
+				"@esbuild/openbsd-x64": "0.27.2",
+				"@esbuild/openharmony-arm64": "0.27.2",
+				"@esbuild/sunos-x64": "0.27.2",
+				"@esbuild/win32-arm64": "0.27.2",
+				"@esbuild/win32-ia32": "0.27.2",
+				"@esbuild/win32-x64": "0.27.2"
 			}
 		},
 		"node_modules/estree-walker": {
@@ -2816,13 +2816,13 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
-			"integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
+			"integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"esbuild": "^0.25.0",
+				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
 				"picomatch": "^4.0.3",
 				"postcss": "^8.5.6",
@@ -3025,33 +3025,33 @@
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.37.1",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.37.1.tgz",
-			"integrity": "sha512-ntm1OsIB2r/f7b5bfS84Lzz5QEx3zn4vUsn1JOVz/+7bw8triyytnxbp68OwOimF1vL5A9sQ0Nd+L6u8F3hECg==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.54.0.tgz",
+			"integrity": "sha512-bANFsjDwJLbprYoBK+hUDZsVbUv2SqJd8QvArLIcZk+fPq4h/Ohtj5vkKXD3k0s2bD1DXLk08D+hYmeNH+xC6A==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
-				"@cloudflare/kv-asset-handler": "0.4.0",
-				"@cloudflare/unenv-preset": "2.7.3",
+				"@cloudflare/kv-asset-handler": "0.4.1",
+				"@cloudflare/unenv-preset": "2.7.13",
 				"blake3-wasm": "2.1.5",
-				"esbuild": "0.25.4",
-				"miniflare": "4.20250913.0",
+				"esbuild": "0.27.0",
+				"miniflare": "4.20251210.0",
 				"path-to-regexp": "6.3.0",
-				"unenv": "2.0.0-rc.21",
-				"workerd": "1.20250913.0"
+				"unenv": "2.0.0-rc.24",
+				"workerd": "1.20251210.0"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
 				"wrangler2": "bin/wrangler.js"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=20.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20250913.0"
+				"@cloudflare/workers-types": "^4.20251210.0"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -3059,10 +3059,39 @@
 				}
 			}
 		},
+		"node_modules/wrangler/node_modules/@cloudflare/kv-asset-handler": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.1.tgz",
+			"integrity": "sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"dependencies": {
+				"mime": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.7.13.tgz",
+			"integrity": "sha512-NulO1H8R/DzsJguLC0ndMuk4Ufv0KSlN+E54ay9rn9ZCQo0kpAPwwh3LhgpZ96a3Dr6L9LqW57M4CqC34iLOvw==",
+			"dev": true,
+			"license": "MIT OR Apache-2.0",
+			"peerDependencies": {
+				"unenv": "2.0.0-rc.24",
+				"workerd": "^1.20251202.0"
+			},
+			"peerDependenciesMeta": {
+				"workerd": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20250913.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250913.0.tgz",
-			"integrity": "sha512-926bBGIYDsF0FraaPQV0hO9LymEN+Zdkkm1qOHxU1c58oAxr5b9Tpe4d1z1EqOD0DTFhjn7V/AxKcZBaBBhO/A==",
+			"version": "1.20251210.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20251210.0.tgz",
+			"integrity": "sha512-Nn9X1moUDERA9xtFdCQ2XpQXgAS9pOjiCxvOT8sVx9UJLAiBLkfSCGbpsYdarODGybXCpjRlc77Yppuolvt7oQ==",
 			"cpu": [
 				"x64"
 			],
@@ -3077,9 +3106,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20250913.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250913.0.tgz",
-			"integrity": "sha512-uy5nJIt44CpICgfsKQotji31cn39i71e2KqE/zeAmmgYp/tzl2cXotVeDtynqqEsloox7hl/eBY5sU0x99N8oQ==",
+			"version": "1.20251210.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20251210.0.tgz",
+			"integrity": "sha512-Mg8iYIZQFnbevq/ls9eW/eneWTk/EE13Pej1MwfkY5et0jVpdHnvOLywy/o+QtMJFef1AjsqXGULwAneYyBfHw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3094,9 +3123,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20250913.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250913.0.tgz",
-			"integrity": "sha512-khdF7MBi8L9WIt3YyWBQxipMny0J3gG824kurZiRACZmPdQ1AOzkKybDDXC3EMcF8TmGMRqKRUGQIB/25PwJuQ==",
+			"version": "1.20251210.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20251210.0.tgz",
+			"integrity": "sha512-kjC2fCZhZ2Gkm1biwk2qByAYpGguK5Gf5ic8owzSCUw0FOUfQxTZUT9Lp3gApxsfTLbbnLBrX/xzWjywH9QR4g==",
 			"cpu": [
 				"x64"
 			],
@@ -3111,9 +3140,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20250913.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250913.0.tgz",
-			"integrity": "sha512-KF5nIOt5YIYGfinY0YEe63JqaAx8WSFDHTLQpytTX+N/oJWEJu3KW6evU1TfX7o8gRlRsc0j/evcZ1vMfbDy5g==",
+			"version": "1.20251210.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20251210.0.tgz",
+			"integrity": "sha512-2IB37nXi7PZVQLa1OCuO7/6pNxqisRSO8DmCQ5x/3sezI5op1vwOxAcb1osAnuVsVN9bbvpw70HJvhKruFJTuA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3128,9 +3157,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20250913.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250913.0.tgz",
-			"integrity": "sha512-m/PMnVdaUB7ymW8BvDIC5xrU16hBDCBpyf9/4y9YZSQOYTVXihxErX8kaW9H9A/I6PTX081NmxxhTbb/n+EQRg==",
+			"version": "1.20251210.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20251210.0.tgz",
+			"integrity": "sha512-Uaz6/9XE+D6E7pCY4OvkCuJHu7HcSDzeGcCGY1HLhojXhHd7yL52c3yfiyJdS8hPatiAa0nn5qSI/42+aTdDSw==",
 			"cpu": [
 				"x64"
 			],
@@ -3145,9 +3174,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
-			"integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+			"integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3162,9 +3191,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/android-arm": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
-			"integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+			"integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
 			"cpu": [
 				"arm"
 			],
@@ -3179,9 +3208,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/android-arm64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
-			"integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+			"integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3196,9 +3225,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/android-x64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
-			"integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+			"integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
 			"cpu": [
 				"x64"
 			],
@@ -3213,9 +3242,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
-			"integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+			"integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3230,9 +3259,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
-			"integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+			"integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
 			"cpu": [
 				"x64"
 			],
@@ -3247,9 +3276,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
-			"integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+			"integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
 			"cpu": [
 				"arm64"
 			],
@@ -3264,9 +3293,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
-			"integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+			"integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
 			"cpu": [
 				"x64"
 			],
@@ -3281,9 +3310,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/linux-arm": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
-			"integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+			"integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
 			"cpu": [
 				"arm"
 			],
@@ -3298,9 +3327,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
-			"integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+			"integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3315,9 +3344,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
-			"integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+			"integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
 			"cpu": [
 				"ia32"
 			],
@@ -3332,9 +3361,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
-			"integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+			"integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
 			"cpu": [
 				"loong64"
 			],
@@ -3349,9 +3378,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
-			"integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+			"integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
 			"cpu": [
 				"mips64el"
 			],
@@ -3366,9 +3395,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
-			"integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+			"integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -3383,9 +3412,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
-			"integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+			"integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -3400,9 +3429,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
-			"integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+			"integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
 			"cpu": [
 				"s390x"
 			],
@@ -3417,9 +3446,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/linux-x64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
-			"integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+			"integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
 			"cpu": [
 				"x64"
 			],
@@ -3434,9 +3463,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
-			"integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+			"integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -3451,9 +3480,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
-			"integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+			"integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
 			"cpu": [
 				"x64"
 			],
@@ -3468,9 +3497,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
-			"integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+			"integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -3485,9 +3514,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
-			"integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+			"integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
 			"cpu": [
 				"x64"
 			],
@@ -3501,10 +3530,27 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+			"integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
-			"integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+			"integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
 			"cpu": [
 				"x64"
 			],
@@ -3519,9 +3565,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
-			"integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+			"integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
 			"cpu": [
 				"arm64"
 			],
@@ -3536,9 +3582,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
-			"integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+			"integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -3553,9 +3599,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/@esbuild/win32-x64": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
-			"integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+			"integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
 			"cpu": [
 				"x64"
 			],
@@ -3570,9 +3616,9 @@
 			}
 		},
 		"node_modules/wrangler/node_modules/esbuild": {
-			"version": "0.25.4",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
-			"integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+			"integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -3583,37 +3629,38 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.4",
-				"@esbuild/android-arm": "0.25.4",
-				"@esbuild/android-arm64": "0.25.4",
-				"@esbuild/android-x64": "0.25.4",
-				"@esbuild/darwin-arm64": "0.25.4",
-				"@esbuild/darwin-x64": "0.25.4",
-				"@esbuild/freebsd-arm64": "0.25.4",
-				"@esbuild/freebsd-x64": "0.25.4",
-				"@esbuild/linux-arm": "0.25.4",
-				"@esbuild/linux-arm64": "0.25.4",
-				"@esbuild/linux-ia32": "0.25.4",
-				"@esbuild/linux-loong64": "0.25.4",
-				"@esbuild/linux-mips64el": "0.25.4",
-				"@esbuild/linux-ppc64": "0.25.4",
-				"@esbuild/linux-riscv64": "0.25.4",
-				"@esbuild/linux-s390x": "0.25.4",
-				"@esbuild/linux-x64": "0.25.4",
-				"@esbuild/netbsd-arm64": "0.25.4",
-				"@esbuild/netbsd-x64": "0.25.4",
-				"@esbuild/openbsd-arm64": "0.25.4",
-				"@esbuild/openbsd-x64": "0.25.4",
-				"@esbuild/sunos-x64": "0.25.4",
-				"@esbuild/win32-arm64": "0.25.4",
-				"@esbuild/win32-ia32": "0.25.4",
-				"@esbuild/win32-x64": "0.25.4"
+				"@esbuild/aix-ppc64": "0.27.0",
+				"@esbuild/android-arm": "0.27.0",
+				"@esbuild/android-arm64": "0.27.0",
+				"@esbuild/android-x64": "0.27.0",
+				"@esbuild/darwin-arm64": "0.27.0",
+				"@esbuild/darwin-x64": "0.27.0",
+				"@esbuild/freebsd-arm64": "0.27.0",
+				"@esbuild/freebsd-x64": "0.27.0",
+				"@esbuild/linux-arm": "0.27.0",
+				"@esbuild/linux-arm64": "0.27.0",
+				"@esbuild/linux-ia32": "0.27.0",
+				"@esbuild/linux-loong64": "0.27.0",
+				"@esbuild/linux-mips64el": "0.27.0",
+				"@esbuild/linux-ppc64": "0.27.0",
+				"@esbuild/linux-riscv64": "0.27.0",
+				"@esbuild/linux-s390x": "0.27.0",
+				"@esbuild/linux-x64": "0.27.0",
+				"@esbuild/netbsd-arm64": "0.27.0",
+				"@esbuild/netbsd-x64": "0.27.0",
+				"@esbuild/openbsd-arm64": "0.27.0",
+				"@esbuild/openbsd-x64": "0.27.0",
+				"@esbuild/openharmony-arm64": "0.27.0",
+				"@esbuild/sunos-x64": "0.27.0",
+				"@esbuild/win32-arm64": "0.27.0",
+				"@esbuild/win32-ia32": "0.27.0",
+				"@esbuild/win32-x64": "0.27.0"
 			}
 		},
 		"node_modules/wrangler/node_modules/miniflare": {
-			"version": "4.20250913.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20250913.0.tgz",
-			"integrity": "sha512-EwlUOxtvb9UKg797YZMCtNga/VSAnKG/kbJX9YGqXJoAJjDhDeAeqyCWjSl9O6EzCZNhtHuW7ZV0pD5Hec617g==",
+			"version": "4.20251210.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20251210.0.tgz",
+			"integrity": "sha512-k6kIoXwGVqlPZb0hcn+X7BmnK+8BjIIkusQPY22kCo2RaQJ/LzAjtxHQdGXerlHSnJyQivDQsL6BJHMpQfUFyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3625,7 +3672,7 @@
 				"sharp": "^0.33.5",
 				"stoppable": "1.1.0",
 				"undici": "7.14.0",
-				"workerd": "1.20250913.0",
+				"workerd": "1.20251210.0",
 				"ws": "8.18.0",
 				"youch": "4.1.0-beta.10",
 				"zod": "3.22.3"
@@ -3637,10 +3684,20 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/wrangler/node_modules/unenv": {
+			"version": "2.0.0-rc.24",
+			"resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+			"integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pathe": "^2.0.3"
+			}
+		},
 		"node_modules/wrangler/node_modules/workerd": {
-			"version": "1.20250913.0",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250913.0.tgz",
-			"integrity": "sha512-y3J1NjCL10SAWDwgGdcNSRyOVod/dWNypu64CCdjj8VS4/k+Ofa/fHaJGC1stbdzAB1tY2P35Ckgm1PU5HKWiw==",
+			"version": "1.20251210.0",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20251210.0.tgz",
+			"integrity": "sha512-9MUUneP1BnRE9XAYi94FXxHmiLGbO75EHQZsgWqSiOXjoXSqJCw8aQbIEPxCy19TclEl/kHUFYce8ST2W+Qpjw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -3651,11 +3708,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20250913.0",
-				"@cloudflare/workerd-darwin-arm64": "1.20250913.0",
-				"@cloudflare/workerd-linux-64": "1.20250913.0",
-				"@cloudflare/workerd-linux-arm64": "1.20250913.0",
-				"@cloudflare/workerd-windows-64": "1.20250913.0"
+				"@cloudflare/workerd-darwin-64": "1.20251210.0",
+				"@cloudflare/workerd-darwin-arm64": "1.20251210.0",
+				"@cloudflare/workerd-linux-64": "1.20251210.0",
+				"@cloudflare/workerd-linux-arm64": "1.20251210.0",
+				"@cloudflare/workerd-windows-64": "1.20251210.0"
 			}
 		},
 		"node_modules/wrangler/node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
 		"@cloudflare/vitest-pool-workers": "^0.8.19",
 		"typescript": "^5.5.2",
 		"vitest": "~3.2.0",
-		"wrangler": "^4.37.1"
+		"wrangler": "^4.54.0"
 	}
 }

--- a/public/index.html
+++ b/public/index.html
@@ -256,6 +256,17 @@
         <p>Share text snippets with public or unlisted links.</p>
       </a>
 
+      <a class="tile" href="/todo" data-keywords="todo task list check organize priority">
+        <div class="tile-icon">
+          <svg viewBox="0 0 24 24">
+            <path d="M9 11l3 3L22 4"></path>
+            <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
+          </svg>
+        </div>
+        <h2>To-Do List</h2>
+        <p>Manage tasks with priorities, due dates, and cloud sync.</p>
+      </a>
+
       <a class="tile" href="/date" data-keywords="date time calculator calendar diff add subtract">
         <div class="tile-icon">
           <svg viewBox="0 0 24 24">

--- a/public/todo.html
+++ b/public/todo.html
@@ -1,0 +1,1202 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>To-Do List</title>
+    <meta name="description" content="A beautiful to-do list app with priorities, due dates, and cloud sync." />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f4f6fb;
+            --fg: #0f172a;
+            --header-bg: #0f172a;
+            --header-fg: #f8fafc;
+            --panel: #ffffff;
+            --border: #d7dce5;
+            --pane-bg: #ffffff;
+            --muted: #52607a;
+            --accent: #2f7cf6;
+            --accent-soft: #e8f1ff;
+            --accent-gradient: linear-gradient(135deg, #2f7cf6 0%, #7c3aed 100%);
+            --success: #10b981;
+            --success-soft: rgba(16, 185, 129, 0.12);
+            --warning: #f59e0b;
+            --warning-soft: rgba(245, 158, 11, 0.12);
+            --danger: #ef4444;
+            --danger-soft: rgba(239, 68, 68, 0.12);
+            --shadow: 0 14px 30px rgba(12, 30, 65, 0.16);
+            --shadow-sm: 0 4px 12px rgba(12, 30, 65, 0.08);
+        }
+
+        [data-theme="dark"] {
+            color-scheme: dark;
+            --bg: #0b1020;
+            --fg: #e5edff;
+            --header-bg: #0f172a;
+            --header-fg: #f8fafc;
+            --panel: #0f172a;
+            --border: #1f2742;
+            --pane-bg: #0f172a;
+            --muted: #91a1c4;
+            --accent: #7aa2f7;
+            --accent-soft: rgba(122, 162, 247, 0.12);
+            --accent-gradient: linear-gradient(135deg, #7aa2f7 0%, #a78bfa 100%);
+            --success: #34d399;
+            --success-soft: rgba(52, 211, 153, 0.15);
+            --warning: #fbbf24;
+            --warning-soft: rgba(251, 191, 36, 0.15);
+            --danger: #f87171;
+            --danger-soft: rgba(248, 113, 113, 0.15);
+            --shadow: 0 14px 30px rgba(0, 0, 0, 0.5);
+            --shadow-sm: 0 4px 12px rgba(0, 0, 0, 0.3);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            height: 100%;
+            margin: 0;
+        }
+
+        body {
+            background: radial-gradient(circle at 20% 20%, rgba(47, 124, 246, 0.08), transparent 25%),
+                radial-gradient(circle at 80% 0%, rgba(124, 58, 237, 0.08), transparent 25%),
+                var(--bg);
+            color: var(--fg);
+            font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, sans-serif;
+        }
+
+        /* Header */
+        .app-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            padding: 0.85rem 1.25rem;
+            border-bottom: 1px solid var(--border);
+            background: var(--header-bg);
+            color: var(--header-fg);
+            position: sticky;
+            top: 0;
+            z-index: 10;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.24);
+        }
+
+        .app-header h1 {
+            margin: 0;
+            font-size: 1.05rem;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .app-header h1 span {
+            font-size: 1.2rem;
+        }
+
+        .app-header .actions {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+        }
+
+        .icon-btn {
+            appearance: none;
+            border: 1px solid var(--border);
+            background: rgba(255, 255, 255, 0.08);
+            color: inherit;
+            padding: 6px 10px;
+            border-radius: 10px;
+            font-size: 0.9rem;
+            line-height: 1;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            cursor: pointer;
+            text-decoration: none;
+            transition: all 0.2s ease;
+        }
+
+        .icon-btn:hover {
+            background: rgba(255, 255, 255, 0.12);
+        }
+
+        /* Page Layout */
+        .page {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 20px 14px 40px;
+        }
+
+        /* Hero Section */
+        .hero {
+            display: grid;
+            grid-template-columns: 1.8fr 1fr;
+            gap: 12px;
+            align-items: center;
+            margin: 14px 0 24px;
+            border: 1px solid var(--border);
+            background: linear-gradient(135deg, rgba(47, 124, 246, 0.12), rgba(124, 58, 237, 0.08)), var(--pane-bg);
+            color: var(--fg);
+            border-radius: 16px;
+            padding: 20px 24px;
+            box-shadow: var(--shadow);
+        }
+
+        .hero h2 {
+            margin: 0 0 6px;
+            font-size: 1.35rem;
+            background: var(--accent-gradient);
+            -webkit-background-clip: text;
+            background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        .hero p {
+            margin: 4px 0 0;
+            color: var(--muted);
+        }
+
+        .kicker {
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            font-size: 0.8rem;
+            color: var(--muted);
+            margin-bottom: 4px;
+        }
+
+        .status-block {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            align-items: flex-start;
+            justify-content: center;
+        }
+
+        .status-pill {
+            padding: .4rem .8rem;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: rgba(255, 255, 255, 0.02);
+            font-weight: 600;
+            font-size: 0.85rem;
+        }
+
+        .status-pill[data-variant="loading"] {
+            border-style: dashed;
+        }
+
+        .status-pill[data-variant="account"] {
+            border-color: var(--success);
+            color: var(--success);
+            background: var(--success-soft);
+        }
+
+        .status-pill[data-variant="guest"] {
+            border-color: var(--warning);
+            color: var(--warning);
+            background: var(--warning-soft);
+        }
+
+        /* Stats Row */
+        .stats-row {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .stat-card {
+            flex: 1;
+            min-width: 120px;
+            padding: 14px 18px;
+            background: var(--pane-bg);
+            border: 1px solid var(--border);
+            border-radius: 14px;
+            box-shadow: var(--shadow-sm);
+            text-align: center;
+        }
+
+        .stat-card .stat-value {
+            font-size: 1.8rem;
+            font-weight: 700;
+            background: var(--accent-gradient);
+            -webkit-background-clip: text;
+            background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        .stat-card .stat-label {
+            font-size: 0.85rem;
+            color: var(--muted);
+            margin-top: 2px;
+        }
+
+        /* Panels */
+        .panel {
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+            background: var(--pane-bg);
+            box-shadow: var(--shadow);
+            margin-bottom: 20px;
+        }
+
+        .panel-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 14px 18px;
+            border-bottom: 1px solid var(--border);
+            background: rgba(255, 255, 255, 0.02);
+        }
+
+        .panel-header strong {
+            font-size: 1rem;
+        }
+
+        .panel-content {
+            padding: 18px;
+        }
+
+        /* Form */
+        .form-row {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            margin-bottom: 12px;
+        }
+
+        .form-row:last-child {
+            margin-bottom: 0;
+        }
+
+        input,
+        select,
+        textarea,
+        button {
+            font: inherit;
+        }
+
+        input,
+        select,
+        textarea {
+            padding: .65rem .8rem;
+            border-radius: 10px;
+            border: 1px solid var(--border);
+            background: transparent;
+            color: inherit;
+            transition: all 0.2s ease;
+        }
+
+        input:focus,
+        select:focus,
+        textarea:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px var(--accent-soft);
+        }
+
+        input.grow,
+        .grow {
+            flex: 1;
+            min-width: 200px;
+        }
+
+        textarea {
+            resize: vertical;
+            min-height: 80px;
+            font-family: inherit;
+        }
+
+        label {
+            display: block;
+            font-size: 0.85rem;
+            color: var(--muted);
+            margin-bottom: 4px;
+        }
+
+        .muted {
+            color: var(--muted);
+            font-size: 0.9rem;
+        }
+
+        .small {
+            font-size: 0.85rem;
+        }
+
+        /* Buttons */
+        button {
+            cursor: pointer;
+        }
+
+        .btn {
+            padding: .65rem 1.2rem;
+            border-radius: 10px;
+            border: 1px solid var(--border);
+            background: transparent;
+            color: inherit;
+            font-weight: 500;
+            transition: all 0.2s ease;
+        }
+
+        .btn:hover {
+            background: rgba(255, 255, 255, 0.05);
+        }
+
+        .btn.primary {
+            background: var(--accent-gradient);
+            border-color: var(--accent);
+            color: #fff;
+            font-weight: 600;
+            box-shadow: 0 8px 24px rgba(47, 124, 246, 0.35);
+        }
+
+        .btn.primary:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 12px 28px rgba(47, 124, 246, 0.4);
+        }
+
+        .btn.ghost {
+            background: rgba(255, 255, 255, 0.05);
+            border-style: dashed;
+        }
+
+        .btn.danger {
+            background: var(--danger-soft);
+            border-color: var(--danger);
+            color: var(--danger);
+        }
+
+        .btn.danger:hover {
+            background: var(--danger);
+            color: white;
+        }
+
+        .btn.sm {
+            padding: .4rem .75rem;
+            font-size: 0.85rem;
+        }
+
+        /* To-Do List */
+        .todo-list {
+            padding: 8px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            max-height: 600px;
+            overflow-y: auto;
+        }
+
+        .todo-item {
+            display: grid;
+            grid-template-columns: auto 1fr auto auto auto;
+            align-items: center;
+            gap: 12px;
+            padding: 14px 16px;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            background: rgba(255, 255, 255, 0.02);
+            transition: all 0.2s ease;
+        }
+
+        .todo-item:hover {
+            transform: translateX(4px);
+            border-color: var(--accent);
+            box-shadow: var(--shadow-sm);
+        }
+
+        .todo-item.completed {
+            opacity: 0.6;
+        }
+
+        .todo-item.completed .todo-title {
+            text-decoration: line-through;
+        }
+
+        /* Checkbox */
+        .checkbox-wrapper {
+            width: 24px;
+            height: 24px;
+            position: relative;
+        }
+
+        .checkbox-wrapper input {
+            position: absolute;
+            opacity: 0;
+            width: 100%;
+            height: 100%;
+            cursor: pointer;
+            z-index: 2;
+        }
+
+        .checkbox-custom {
+            width: 24px;
+            height: 24px;
+            border: 2px solid var(--border);
+            border-radius: 6px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: all 0.2s ease;
+            background: transparent;
+        }
+
+        .checkbox-wrapper input:checked+.checkbox-custom {
+            background: var(--success);
+            border-color: var(--success);
+        }
+
+        .checkbox-custom::after {
+            content: '✓';
+            color: white;
+            font-size: 14px;
+            font-weight: 700;
+            opacity: 0;
+            transform: scale(0);
+            transition: all 0.2s ease;
+        }
+
+        .checkbox-wrapper input:checked+.checkbox-custom::after {
+            opacity: 1;
+            transform: scale(1);
+        }
+
+        .todo-content {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+            min-width: 0;
+        }
+
+        .todo-title {
+            font-weight: 600;
+            font-size: 1rem;
+            word-break: break-word;
+        }
+
+        .todo-meta {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        /* Priority Pills */
+        .priority-pill {
+            font-size: 0.75rem;
+            padding: 3px 10px;
+            border-radius: 999px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .priority-pill.high {
+            background: var(--danger-soft);
+            color: var(--danger);
+        }
+
+        .priority-pill.medium {
+            background: var(--warning-soft);
+            color: var(--warning);
+        }
+
+        .priority-pill.low {
+            background: var(--success-soft);
+            color: var(--success);
+        }
+
+        /* Category Pills */
+        .category-pill {
+            font-size: 0.7rem;
+            padding: 2px 8px;
+            border-radius: 6px;
+            font-weight: 500;
+            background: var(--accent-soft);
+            color: var(--accent);
+            border: 1px solid transparent;
+        }
+
+        .category-pill.work {
+            background: rgba(59, 130, 246, 0.15);
+            color: #3b82f6;
+        }
+
+        .category-pill.personal {
+            background: rgba(168, 85, 247, 0.15);
+            color: #a855f7;
+        }
+
+        .category-pill.projects {
+            background: rgba(14, 165, 233, 0.15);
+            color: #0ea5e9;
+        }
+
+        .category-pill.shopping {
+            background: rgba(236, 72, 153, 0.15);
+            color: #ec4899;
+        }
+
+        .category-pill.health {
+            background: rgba(34, 197, 94, 0.15);
+            color: #22c55e;
+        }
+
+        .category-pill.finance {
+            background: rgba(234, 179, 8, 0.15);
+            color: #eab308;
+        }
+
+        .category-pill.other {
+            background: rgba(107, 114, 128, 0.15);
+            color: #6b7280;
+        }
+
+        /* Due Date */
+        .due-date {
+            font-size: 0.8rem;
+            color: var(--muted);
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .due-date.overdue {
+            color: var(--danger);
+        }
+
+        .due-date.today {
+            color: var(--warning);
+        }
+
+        .todo-actions {
+            display: flex;
+            gap: 6px;
+            opacity: 0.6;
+            transition: opacity 0.2s;
+        }
+
+        .todo-item:hover .todo-actions {
+            opacity: 1;
+        }
+
+        /* Filter/Sort Bar */
+        .filter-bar {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .filter-bar select {
+            min-width: 120px;
+        }
+
+        /* Empty State */
+        .empty-state {
+            text-align: center;
+            padding: 48px 24px;
+            color: var(--muted);
+        }
+
+        .empty-state .empty-icon {
+            font-size: 4rem;
+            margin-bottom: 16px;
+            opacity: 0.5;
+        }
+
+        .empty-state h3 {
+            margin: 0 0 8px;
+            color: var(--fg);
+        }
+
+        .empty-state p {
+            margin: 0;
+        }
+
+        /* Auth Required */
+        .auth-required {
+            text-align: center;
+            padding: 48px 24px;
+        }
+
+        .auth-required .auth-icon {
+            font-size: 4rem;
+            margin-bottom: 16px;
+        }
+
+        .auth-required h3 {
+            margin: 0 0 12px;
+        }
+
+        .auth-required p {
+            color: var(--muted);
+            margin: 0 0 20px;
+        }
+
+        .auth-required a {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 12px 24px;
+            background: var(--accent-gradient);
+            color: white;
+            text-decoration: none;
+            border-radius: 10px;
+            font-weight: 600;
+            box-shadow: 0 8px 24px rgba(47, 124, 246, 0.35);
+            transition: all 0.2s ease;
+        }
+
+        .auth-required a:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 28px rgba(47, 124, 246, 0.4);
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .hero {
+                grid-template-columns: 1fr;
+            }
+
+            .status-block {
+                margin-top: 12px;
+            }
+
+            .todo-item {
+                grid-template-columns: auto 1fr;
+            }
+
+            .todo-item .priority-pill {
+                grid-column: 2;
+            }
+
+            .todo-actions {
+                grid-column: 2;
+                justify-content: flex-end;
+                margin-top: 8px;
+            }
+        }
+
+        @media (max-width: 500px) {
+            .app-header h1 {
+                font-size: 0.95rem;
+            }
+
+            .stats-row {
+                flex-direction: column;
+            }
+
+            .form-row {
+                flex-direction: column;
+            }
+
+            .form-row .grow {
+                min-width: 100%;
+            }
+        }
+
+        /* Animations */
+        @keyframes fadeIn {
+            from {
+                opacity: 0;
+                transform: translateY(8px);
+            }
+
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .todo-item {
+            animation: fadeIn 0.25s ease;
+        }
+
+        @keyframes pulse {
+
+            0%,
+            100% {
+                opacity: 1;
+            }
+
+            50% {
+                opacity: 0.5;
+            }
+        }
+
+        .loading {
+            animation: pulse 1.5s infinite;
+        }
+    </style>
+</head>
+
+<body>
+    <header class="app-header">
+        <h1><span>✅</span> To-Do List</h1>
+        <div class="actions">
+            <a href="/" class="icon-btn" title="Home" aria-label="Home">🏠</a>
+            <button id="toggleTheme" class="icon-btn" title="Toggle theme">🌙</button>
+            <div id="authArea" class="row"></div>
+        </div>
+    </header>
+
+    <div class="page">
+        <!-- Hero Section -->
+        <section class="hero">
+            <div>
+                <div class="kicker">Stay organized</div>
+                <h2>Manage your tasks with ease</h2>
+                <p>Create, prioritize, and track your to-dos. Sign in to sync across devices.</p>
+            </div>
+            <div class="status-block">
+                <div class="muted small">Status</div>
+                <div id="modePill" class="status-pill" data-variant="loading">Checking access…</div>
+            </div>
+        </section>
+
+        <!-- Stats Row -->
+        <div class="stats-row" id="statsRow" style="display: none;">
+            <div class="stat-card">
+                <div class="stat-value" id="statTotal">0</div>
+                <div class="stat-label">Total</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="statPending">0</div>
+                <div class="stat-label">Pending</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="statCompleted">0</div>
+                <div class="stat-label">Completed</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="statHigh">0</div>
+                <div class="stat-label">High Priority</div>
+            </div>
+        </div>
+
+        <!-- Create Panel -->
+        <section class="panel" id="createPanel" style="display: none;">
+            <div class="panel-header">
+                <strong>➕ Add New Task</strong>
+            </div>
+            <div class="panel-content">
+                <div class="form-row">
+                    <input type="text" id="todoTitle" class="grow" placeholder="What needs to be done?" />
+                </div>
+                <div class="form-row">
+                    <textarea id="todoDescription" placeholder="Description (optional)"></textarea>
+                </div>
+                <div class="form-row">
+                    <div>
+                        <label for="todoPriority">Priority</label>
+                        <select id="todoPriority">
+                            <option value="medium">Medium</option>
+                            <option value="high">High</option>
+                            <option value="low">Low</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="todoCategory">Category</label>
+                        <select id="todoCategory">
+                            <option value="personal">🏠 Personal</option>
+                            <option value="work">💼 Work</option>
+                            <option value="projects">📁 Projects</option>
+                            <option value="shopping">🛒 Shopping</option>
+                            <option value="health">💪 Health</option>
+                            <option value="finance">💰 Finance</option>
+                            <option value="other">📌 Other</option>
+                        </select>
+                    </div>
+                    <div style="flex: 1;">
+                        <label for="todoDueDate">Due Date (optional)</label>
+                        <input type="date" id="todoDueDate" style="width: 100%;" />
+                    </div>
+                    <button id="createBtn" class="btn primary" style="align-self: flex-end;">Create Task</button>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tasks List Panel -->
+        <section class="panel" id="tasksPanel" style="display: none;">
+            <div class="panel-header">
+                <strong>📋 Your Tasks</strong>
+                <div class="filter-bar">
+                    <select id="filterStatus">
+                        <option value="all">All</option>
+                        <option value="pending">Pending</option>
+                        <option value="completed">Completed</option>
+                    </select>
+                    <select id="filterPriority">
+                        <option value="all">All Priorities</option>
+                        <option value="high">High</option>
+                        <option value="medium">Medium</option>
+                        <option value="low">Low</option>
+                    </select>
+                    <select id="filterCategory">
+                        <option value="all">All Categories</option>
+                        <option value="personal">🏠 Personal</option>
+                        <option value="work">💼 Work</option>
+                        <option value="projects">📁 Projects</option>
+                        <option value="shopping">🛒 Shopping</option>
+                        <option value="health">💪 Health</option>
+                        <option value="finance">💰 Finance</option>
+                        <option value="other">📌 Other</option>
+                    </select>
+                    <button id="refreshBtn" class="btn ghost sm">Refresh</button>
+                </div>
+            </div>
+            <div class="todo-list" id="todoList">
+                <div class="muted loading">Loading tasks...</div>
+            </div>
+        </section>
+
+        <!-- Auth Required State -->
+        <section class="panel" id="authPanel">
+            <div class="auth-required">
+                <div class="auth-icon">🔐</div>
+                <h3>Sign in to get started</h3>
+                <p>Your to-do items are saved to your account and synced across all your devices.</p>
+                <a href="/auth/google/login">
+                    <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                        <path
+                            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+                        <path
+                            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+                        <path
+                            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+                        <path
+                            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+                    </svg>
+                    Sign in with Google
+                </a>
+            </div>
+        </section>
+    </div>
+
+    <script>
+        const qs = (sel) => document.querySelector(sel);
+        const THEME_KEY = 'todo_theme';
+        const root = document.documentElement;
+
+        function preferredTheme() {
+            const saved = localStorage.getItem(THEME_KEY);
+            if (saved === 'light' || saved === 'dark') return saved;
+            return (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+        }
+
+        function applyTheme(theme) {
+            root.setAttribute('data-theme', theme);
+            localStorage.setItem(THEME_KEY, theme);
+            const btn = document.getElementById('toggleTheme');
+            if (btn) btn.textContent = (theme === 'dark') ? '☀️' : '🌙';
+        }
+
+        async function api(path, opts = {}) {
+            const res = await fetch(path, Object.assign({ credentials: 'include' }, opts));
+            if (!res.ok) throw new Error(await res.text());
+            return res.json();
+        }
+
+        function el(tag, attrs = {}, children = []) {
+            const e = document.createElement(tag);
+            Object.entries(attrs).forEach(([k, v]) => {
+                if (k === 'class') e.className = v;
+                else if (k.startsWith('on')) e[k] = v;
+                else if (k === 'checked') e.checked = v;
+                else e.setAttribute(k, v);
+            });
+            children.forEach(c => e.appendChild(typeof c === 'string' ? document.createTextNode(c) : c));
+            return e;
+        }
+
+        let TODO_STATE = { loggedIn: false, user: null };
+        let TODOS = [];
+
+        function setModeLabel(text, variant = 'loading') {
+            const pill = qs('#modePill');
+            if (!pill) return;
+            pill.textContent = text;
+            pill.setAttribute('data-variant', variant);
+        }
+
+        function updateStats() {
+            const total = TODOS.length;
+            const completed = TODOS.filter(t => t.completed).length;
+            const pending = total - completed;
+            const high = TODOS.filter(t => t.priority === 'high' && !t.completed).length;
+
+            qs('#statTotal').textContent = total;
+            qs('#statPending').textContent = pending;
+            qs('#statCompleted').textContent = completed;
+            qs('#statHigh').textContent = high;
+        }
+
+        function formatDueDate(dueDateStr) {
+            if (!dueDateStr) return null;
+            const due = new Date(dueDateStr + 'T00:00:00');
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            const diff = Math.floor((due - today) / (1000 * 60 * 60 * 24));
+
+            let cls = '';
+            let text = due.toLocaleDateString();
+
+            if (diff < 0) {
+                cls = 'overdue';
+                text = `Overdue (${-diff} ${-diff === 1 ? 'day' : 'days'})`;
+            } else if (diff === 0) {
+                cls = 'today';
+                text = 'Due today';
+            } else if (diff === 1) {
+                text = 'Due tomorrow';
+            } else if (diff <= 7) {
+                text = `Due in ${diff} days`;
+            }
+
+            return { cls, text };
+        }
+
+        function getCategoryLabel(category) {
+            const labels = {
+                personal: '🏠 Personal',
+                work: '💼 Work',
+                projects: '📁 Projects',
+                shopping: '🛒 Shopping',
+                health: '💪 Health',
+                finance: '💰 Finance',
+                other: '📌 Other'
+            };
+            return labels[category] || labels.personal;
+        }
+
+        function renderTodos() {
+            const list = qs('#todoList');
+            const filterStatus = qs('#filterStatus').value;
+            const filterPriority = qs('#filterPriority').value;
+            const filterCategory = qs('#filterCategory').value;
+
+            let filtered = [...TODOS];
+
+            if (filterStatus === 'pending') {
+                filtered = filtered.filter(t => !t.completed);
+            } else if (filterStatus === 'completed') {
+                filtered = filtered.filter(t => t.completed);
+            }
+
+            if (filterPriority !== 'all') {
+                filtered = filtered.filter(t => t.priority === filterPriority);
+            }
+
+            if (filterCategory !== 'all') {
+                filtered = filtered.filter(t => t.category === filterCategory);
+            }
+
+            list.innerHTML = '';
+
+            if (filtered.length === 0) {
+                const noFilters = filterStatus === 'all' && filterPriority === 'all' && filterCategory === 'all';
+                const empty = el('div', { class: 'empty-state' }, [
+                    el('div', { class: 'empty-icon' }, ['📝']),
+                    el('h3', {}, [noFilters ? 'No tasks yet' : 'No matching tasks']),
+                    el('p', {}, [noFilters ? 'Add your first task above to get started!' : 'Try adjusting your filters.'])
+                ]);
+                list.appendChild(empty);
+                return;
+            }
+
+            filtered.forEach(todo => {
+                const due = formatDueDate(todo.due_date);
+
+                const item = el('div', { class: `todo-item ${todo.completed ? 'completed' : ''}` }, [
+                    el('div', { class: 'checkbox-wrapper' }, [
+                        el('input', {
+                            type: 'checkbox',
+                            checked: !!todo.completed,
+                            title: 'Toggle completion',
+                            onchange: () => toggleTodo(todo.id)
+                        }),
+                        el('span', { class: 'checkbox-custom' })
+                    ]),
+                    el('div', { class: 'todo-content' }, [
+                        el('div', { class: 'todo-title' }, [todo.title]),
+                        el('div', { class: 'todo-meta' }, [
+                            el('span', { class: `category-pill ${todo.category || 'personal'}` }, [getCategoryLabel(todo.category)]),
+                            ...(todo.description ? [el('span', { class: 'muted small' }, [todo.description.length > 50 ? todo.description.slice(0, 50) + '...' : todo.description])] : []),
+                            ...(due ? [el('span', { class: `due-date ${due.cls}` }, ['📅 ' + due.text])] : [])
+                        ])
+                    ]),
+                    el('span', { class: `priority-pill ${todo.priority}` }, [todo.priority]),
+                    el('div', { class: 'todo-actions' }, [
+                        el('button', {
+                            class: 'btn ghost sm',
+                            title: 'Delete task',
+                            onclick: () => deleteTodo(todo.id)
+                        }, ['🗑️'])
+                    ])
+                ]);
+
+                list.appendChild(item);
+            });
+
+            updateStats();
+        }
+
+        async function loadTodos() {
+            try {
+                const data = await api('/api/todo/list');
+                TODOS = data || [];
+                renderTodos();
+            } catch (e) {
+                console.error('Failed to load todos:', e);
+                qs('#todoList').innerHTML = '<div class="muted">Failed to load tasks. Please try again.</div>';
+            }
+        }
+
+        async function createTodo() {
+            const title = qs('#todoTitle').value.trim();
+            const description = qs('#todoDescription').value.trim();
+            const priority = qs('#todoPriority').value;
+            const category = qs('#todoCategory').value;
+            const dueDate = qs('#todoDueDate').value || null;
+
+            if (!title) {
+                alert('Please enter a task title');
+                return;
+            }
+
+            try {
+                await api('/api/todo/create', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({ title, description: description || null, priority, category, due_date: dueDate })
+                });
+
+                // Clear form
+                qs('#todoTitle').value = '';
+                qs('#todoDescription').value = '';
+                qs('#todoPriority').value = 'medium';
+                qs('#todoCategory').value = 'personal';
+                qs('#todoDueDate').value = '';
+
+                // Reload list
+                loadTodos();
+            } catch (e) {
+                alert('Failed to create task: ' + e.message);
+            }
+        }
+
+        async function toggleTodo(id) {
+            try {
+                await api('/api/todo/toggle', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({ id })
+                });
+                loadTodos();
+            } catch (e) {
+                alert('Failed to update task: ' + e.message);
+            }
+        }
+
+        async function deleteTodo(id) {
+            if (!confirm('Delete this task? This cannot be undone.')) return;
+            try {
+                await api('/api/todo/delete', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({ id })
+                });
+                loadTodos();
+            } catch (e) {
+                alert('Failed to delete task: ' + e.message);
+            }
+        }
+
+        async function refreshAuth() {
+            try {
+                const me = await api('/api/auth/me');
+                TODO_STATE = me || { loggedIn: false, user: null };
+
+                if (me.loggedIn) {
+                    qs('#authArea').innerHTML = '';
+                    qs('#authArea').appendChild(
+                        el('span', { class: 'muted' }, [me.user.email])
+                    );
+                    qs('#authArea').appendChild(
+                        el('button', {
+                            class: 'icon-btn',
+                            onclick: async () => {
+                                await api('/api/auth/logout', { method: 'POST' });
+                                location.reload();
+                            }
+                        }, ['Logout'])
+                    );
+
+                    setModeLabel('Signed in', 'account');
+
+                    // Show panels
+                    qs('#authPanel').style.display = 'none';
+                    qs('#createPanel').style.display = '';
+                    qs('#tasksPanel').style.display = '';
+                    qs('#statsRow').style.display = '';
+
+                    // Load todos
+                    loadTodos();
+                } else {
+                    qs('#authArea').innerHTML = '';
+                    qs('#authArea').appendChild(
+                        el('a', { href: '/auth/google/login', class: 'icon-btn' }, ['Login'])
+                    );
+
+                    setModeLabel('Not signed in', 'guest');
+
+                    // Show auth panel
+                    qs('#authPanel').style.display = '';
+                    qs('#createPanel').style.display = 'none';
+                    qs('#tasksPanel').style.display = 'none';
+                    qs('#statsRow').style.display = 'none';
+                }
+            } catch (e) {
+                console.error(e);
+                setModeLabel('Error checking access', 'guest');
+            }
+        }
+
+        // Event Listeners
+        applyTheme(preferredTheme());
+
+        qs('#toggleTheme').addEventListener('click', () => {
+            const current = root.getAttribute('data-theme') || preferredTheme();
+            applyTheme(current === 'dark' ? 'light' : 'dark');
+        });
+
+        qs('#createBtn').addEventListener('click', createTodo);
+        qs('#todoTitle').addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') createTodo();
+        });
+
+        qs('#refreshBtn').addEventListener('click', loadTodos);
+        qs('#filterStatus').addEventListener('change', renderTodos);
+        qs('#filterPriority').addEventListener('change', renderTodos);
+        qs('#filterCategory').addEventListener('change', renderTodos);
+
+        // Initialize
+        refreshAuth();
+    </script>
+</body>
+
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { handleAuthRoutes } from './auth';
 import { handlePastebinApi, handlePastebinPage } from './pastebin';
+import { handleTodoApi } from './todo';
 import { handleTranscriptApi } from './routes/transcript';
 import { serveStatic } from './static';
 import type { Bindings, WorkerExport } from './types';
@@ -14,6 +15,9 @@ export default {
 
     const pastebinApiResponse = await handlePastebinApi(request, bindings, url);
     if (pastebinApiResponse) return pastebinApiResponse;
+
+    const todoApiResponse = await handleTodoApi(request, bindings, url);
+    if (todoApiResponse) return todoApiResponse;
 
     const transcriptResponse = await handleTranscriptApi(request, bindings, url);
     if (transcriptResponse) return transcriptResponse;

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -1,0 +1,231 @@
+import { requireUser } from './auth';
+import { badRequest, json, readJson } from './utils/http';
+import { urlSafeRandom } from './utils/random';
+import type { Bindings, HandlerResult } from './types';
+
+type Priority = 'low' | 'medium' | 'high';
+type Category = 'personal' | 'work' | 'projects' | 'shopping' | 'health' | 'finance' | 'other';
+
+const VALID_CATEGORIES: Category[] = ['personal', 'work', 'projects', 'shopping', 'health', 'finance', 'other'];
+
+interface Todo {
+    id: string;
+    user_id: string;
+    title: string;
+    description: string | null;
+    completed: number;
+    priority: Priority;
+    category: Category;
+    due_date: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+async function createTodo(
+    env: Bindings,
+    userId: string,
+    title: string,
+    description: string | null,
+    priority: Priority,
+    category: Category,
+    dueDate: string | null,
+): Promise<Response> {
+    if (!title) return badRequest('title required');
+    for (let i = 0; i < 5; i++) {
+        const id = urlSafeRandom(12);
+        const exists = await env.DB.prepare('SELECT id FROM todos WHERE id = ?').bind(id).first();
+        if (exists) continue;
+        await env.DB.prepare(
+            'INSERT INTO todos (id, user_id, title, description, priority, category, due_date) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        )
+            .bind(id, userId, title, description, priority, category, dueDate)
+            .run();
+        return json({ id });
+    }
+    return badRequest('Failed to allocate id', 500);
+}
+
+async function listTodos(env: Bindings, userId: string): Promise<Response> {
+    // Order by: incomplete first, then priority (high->medium->low), then due_date (earliest first, nulls last)
+    const rows = await env.DB.prepare(
+        `SELECT id, title, description, completed, priority, category, due_date, created_at, updated_at 
+     FROM todos WHERE user_id = ? 
+     ORDER BY completed ASC, 
+              CASE priority WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 3 END, 
+              CASE WHEN due_date IS NULL THEN 1 ELSE 0 END, 
+              due_date ASC,
+              created_at DESC 
+     LIMIT 500`,
+    )
+        .bind(userId)
+        .all();
+    return json(rows.results || []);
+}
+
+async function getTodo(env: Bindings, userId: string, id: string): Promise<Response> {
+    if (!id) return badRequest('id required');
+    const row = (await env.DB.prepare(
+        'SELECT id, title, description, completed, priority, category, due_date, created_at, updated_at FROM todos WHERE id = ? AND user_id = ?',
+    )
+        .bind(id, userId)
+        .first()) as Todo | null;
+    if (!row) return new Response('Not found', { status: 404 });
+    return json(row);
+}
+
+async function updateTodo(
+    request: Request,
+    env: Bindings,
+    userId: string,
+): Promise<Response> {
+    const body = await readJson<{
+        id?: string;
+        title?: string;
+        description?: string;
+        completed?: boolean;
+        priority?: Priority;
+        category?: Category;
+        due_date?: string | null;
+    }>(request);
+    const id = (body.id || '').toString();
+    if (!id) return badRequest('id required');
+
+    const row = (await env.DB.prepare('SELECT user_id FROM todos WHERE id = ?').bind(id).first()) as any;
+    if (!row) return new Response('Not found', { status: 404 });
+    if (row.user_id !== userId) return new Response('Forbidden', { status: 403 });
+
+    const updates: string[] = [];
+    const values: any[] = [];
+
+    if (body.title !== undefined) {
+        if (!body.title) return badRequest('title cannot be empty');
+        updates.push('title = ?');
+        values.push(body.title);
+    }
+    if (body.description !== undefined) {
+        updates.push('description = ?');
+        values.push(body.description || null);
+    }
+    if (body.completed !== undefined) {
+        updates.push('completed = ?');
+        values.push(body.completed ? 1 : 0);
+    }
+    if (body.priority !== undefined) {
+        if (!['low', 'medium', 'high'].includes(body.priority)) {
+            return badRequest('priority must be low, medium, or high');
+        }
+        updates.push('priority = ?');
+        values.push(body.priority);
+    }
+    if (body.due_date !== undefined) {
+        updates.push('due_date = ?');
+        values.push(body.due_date || null);
+    }
+    if (body.category !== undefined) {
+        if (!VALID_CATEGORIES.includes(body.category)) {
+            return badRequest('category must be personal, work, shopping, health, finance, or other');
+        }
+        updates.push('category = ?');
+        values.push(body.category);
+    }
+
+    if (updates.length === 0) {
+        return badRequest('No fields to update');
+    }
+
+    updates.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')");
+    values.push(id);
+
+    await env.DB.prepare(`UPDATE todos SET ${updates.join(', ')} WHERE id = ?`)
+        .bind(...values)
+        .run();
+
+    return json({ ok: true });
+}
+
+async function deleteTodo(request: Request, env: Bindings, userId: string): Promise<Response> {
+    const body = await readJson<{ id?: string }>(request);
+    const id = (body.id || '').toString();
+    if (!id) return badRequest('id required');
+    const row = (await env.DB.prepare('SELECT user_id FROM todos WHERE id = ?').bind(id).first()) as any;
+    if (!row) return new Response('Not found', { status: 404 });
+    if (row.user_id !== userId) return new Response('Forbidden', { status: 403 });
+    await env.DB.prepare('DELETE FROM todos WHERE id = ?').bind(id).run();
+    return json({ ok: true });
+}
+
+async function toggleTodo(request: Request, env: Bindings, userId: string): Promise<Response> {
+    const body = await readJson<{ id?: string }>(request);
+    const id = (body.id || '').toString();
+    if (!id) return badRequest('id required');
+    const row = (await env.DB.prepare('SELECT user_id, completed FROM todos WHERE id = ?').bind(id).first()) as any;
+    if (!row) return new Response('Not found', { status: 404 });
+    if (row.user_id !== userId) return new Response('Forbidden', { status: 403 });
+    const newCompleted = row.completed ? 0 : 1;
+    await env.DB.prepare("UPDATE todos SET completed = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = ?")
+        .bind(newCompleted, id)
+        .run();
+    return json({ ok: true, completed: !!newCompleted });
+}
+
+export async function handleTodoApi(
+    request: Request,
+    env: Bindings,
+    url: URL,
+): Promise<HandlerResult> {
+    const path = url.pathname;
+
+    if (path === '/api/todo/create' && request.method === 'POST') {
+        const user = await requireUser(request, env);
+        if (user instanceof Response) return user;
+        const body = await readJson<{
+            title?: string;
+            description?: string;
+            priority?: Priority;
+            category?: Category;
+            due_date?: string;
+        }>(request);
+        const title = (body.title || '').toString().trim();
+        const description = body.description ? body.description.toString() : null;
+        const priority: Priority =
+            body.priority === 'low' ? 'low' : body.priority === 'high' ? 'high' : 'medium';
+        const category: Category = VALID_CATEGORIES.includes(body.category as Category)
+            ? (body.category as Category)
+            : 'personal';
+        const dueDate = body.due_date ? body.due_date.toString() : null;
+        return createTodo(env, (user as any).id, title, description, priority, category, dueDate);
+    }
+
+    if (path === '/api/todo/list' && request.method === 'GET') {
+        const user = await requireUser(request, env);
+        if (user instanceof Response) return user;
+        return listTodos(env, (user as any).id);
+    }
+
+    if (path === '/api/todo/get' && request.method === 'GET') {
+        const user = await requireUser(request, env);
+        if (user instanceof Response) return user;
+        const id = url.searchParams.get('id') || '';
+        return getTodo(env, (user as any).id, id);
+    }
+
+    if (path === '/api/todo/update' && request.method === 'POST') {
+        const user = await requireUser(request, env);
+        if (user instanceof Response) return user;
+        return updateTodo(request, env, (user as any).id);
+    }
+
+    if (path === '/api/todo/delete' && request.method === 'POST') {
+        const user = await requireUser(request, env);
+        if (user instanceof Response) return user;
+        return deleteTodo(request, env, (user as any).id);
+    }
+
+    if (path === '/api/todo/toggle' && request.method === 'POST') {
+        const user = await requireUser(request, env);
+        if (user instanceof Response) return user;
+        return toggleTodo(request, env, (user as any).id);
+    }
+
+    return null;
+}


### PR DESCRIPTION
## Summary
- add D1 migrations for todos with categories and indexes
- implement authenticated todo CRUD/toggle API routes
- ship todo HTML UI with stats, filters, and theme toggle
- add home tile entry for the todo tool
- bump wrangler to 4.54.0 (lockfile refresh)

## Testing
- not run