### PR TITLE
Add image editor web tool

### DIFF
--- a/public/image-editor.html
+++ b/public/image-editor.html
@@ -1,0 +1,1568 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Image Editor</title>
+    <link rel="stylesheet" href="/shared/toolkit.css" />
+    <script defer src="/shared/toolkit.js"></script>
+    <style>
+      :root {
+        --panel: var(--wt-panel-solid);
+        --border: var(--wt-border);
+        --muted: var(--wt-muted);
+        --accent: var(--wt-accent);
+        --accent-soft: var(--wt-accent-soft);
+        --success: var(--wt-success);
+        --danger: var(--wt-danger);
+        --warning: var(--wt-warning);
+        --stage-bg: rgba(15, 23, 42, 0.1);
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        color: var(--wt-fg);
+      }
+
+      .page {
+        display: grid;
+        gap: 18px;
+      }
+
+      .hero,
+      .panel,
+      .stage-panel {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 18px;
+        box-shadow: var(--wt-shadow-sm);
+      }
+
+      .hero {
+        padding: 20px;
+        display: grid;
+        gap: 10px;
+      }
+
+      .hero h1 {
+        margin: 0;
+        font-size: 1.7rem;
+      }
+
+      .hero p {
+        margin: 0;
+        color: var(--muted);
+        max-width: 72ch;
+      }
+
+      .hero-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .hero-list span {
+        padding: 7px 10px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: rgba(127, 127, 127, 0.08);
+        font-size: 0.88rem;
+        color: var(--muted);
+      }
+
+      .workspace {
+        display: grid;
+        gap: 18px;
+        grid-template-columns: minmax(300px, 360px) minmax(0, 1fr);
+        align-items: stretch;
+      }
+
+      .controls {
+        display: grid;
+        gap: 16px;
+        align-content: start;
+      }
+
+      .panel {
+        overflow: hidden;
+      }
+
+      .panel-head {
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+      }
+
+      .panel-head h2 {
+        margin: 0;
+        font-size: 0.96rem;
+      }
+
+      .panel-body {
+        padding: 14px;
+        display: grid;
+        gap: 14px;
+      }
+
+      .field {
+        display: grid;
+        gap: 6px;
+      }
+
+      .field label,
+      .field-header {
+        font-size: 0.86rem;
+        color: var(--muted);
+        font-weight: 600;
+      }
+
+      .drop-zone {
+        width: 100%;
+        min-height: 132px;
+        border: 2px dashed var(--border);
+        border-radius: 18px;
+        background:
+          radial-gradient(circle at top right, rgba(14, 165, 233, 0.1), transparent 42%),
+          rgba(127, 127, 127, 0.05);
+        color: inherit;
+        cursor: pointer;
+        display: grid;
+        place-items: center;
+        text-align: center;
+        padding: 18px;
+        transition: border-color 0.15s ease, background-color 0.15s ease, transform 0.15s ease;
+      }
+
+      .drop-zone strong {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 1rem;
+      }
+
+      .drop-zone p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      .drop-zone.drag-over,
+      body.dragging .drop-zone {
+        border-color: var(--accent);
+        background:
+          radial-gradient(circle at top right, rgba(14, 165, 233, 0.16), transparent 45%),
+          rgba(37, 99, 235, 0.08);
+      }
+
+      .hint,
+      .meta-note {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.87rem;
+      }
+
+      .btn-row,
+      .toolbar-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .btn-row .wt-btn,
+      .toolbar-row .wt-btn {
+        justify-content: center;
+      }
+
+      .btn-row .wt-btn {
+        flex: 1 1 0;
+      }
+
+      .meta-grid {
+        display: grid;
+        gap: 10px;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .meta-item {
+        border: 1px solid var(--border);
+        border-radius: 14px;
+        padding: 10px;
+        background: rgba(127, 127, 127, 0.05);
+      }
+
+      .meta-item strong {
+        display: block;
+        margin-bottom: 4px;
+        color: var(--muted);
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+      }
+
+      .meta-item span {
+        display: block;
+        min-height: 1.3em;
+        font-size: 0.94rem;
+        word-break: break-word;
+      }
+
+      .control-stack {
+        display: grid;
+        gap: 12px;
+      }
+
+      .scale-row {
+        display: grid;
+        gap: 10px;
+        grid-template-columns: 1fr auto;
+        align-items: center;
+      }
+
+      .range-wrap {
+        display: grid;
+        gap: 6px;
+      }
+
+      input[type='range'] {
+        width: 100%;
+        accent-color: var(--accent);
+      }
+
+      .scale-label,
+      .value-label {
+        min-width: 64px;
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      .select-row {
+        display: grid;
+        gap: 10px;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: end;
+      }
+
+      .wt-select,
+      .text-input {
+        width: 100%;
+      }
+
+      .text-input {
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        background: rgba(255, 255, 255, 0.06);
+        padding: 8px 10px;
+      }
+
+      .stage-panel {
+        min-height: 720px;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+        overflow: hidden;
+      }
+
+      .stage-head {
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+
+      .stage-head h2 {
+        margin: 0;
+        font-size: 0.96rem;
+      }
+
+      .status {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        border-radius: 999px;
+        padding: 7px 10px;
+        font-size: 0.86rem;
+        border: 1px solid var(--border);
+        background: rgba(127, 127, 127, 0.06);
+      }
+
+      .status[data-kind='success'] {
+        color: var(--success);
+        border-color: color-mix(in srgb, var(--success) 40%, var(--border));
+      }
+
+      .status[data-kind='error'] {
+        color: var(--danger);
+        border-color: color-mix(in srgb, var(--danger) 40%, var(--border));
+      }
+
+      .status[data-kind='warning'] {
+        color: var(--warning);
+        border-color: color-mix(in srgb, var(--warning) 40%, var(--border));
+      }
+
+      .stage-viewport {
+        position: relative;
+        overflow: auto;
+        background:
+          radial-gradient(circle at top left, rgba(37, 99, 235, 0.14), transparent 38%),
+          radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.16), transparent 34%),
+          var(--stage-bg);
+      }
+
+      .stage-surface {
+        min-width: 100%;
+        min-height: 100%;
+        padding: 28px;
+        display: grid;
+        place-items: center;
+      }
+
+      .checkerboard {
+        position: absolute;
+        inset: 0;
+        background-image:
+          linear-gradient(45deg, rgba(255, 255, 255, 0.08) 25%, transparent 25%),
+          linear-gradient(-45deg, rgba(255, 255, 255, 0.08) 25%, transparent 25%),
+          linear-gradient(45deg, transparent 75%, rgba(255, 255, 255, 0.08) 75%),
+          linear-gradient(-45deg, transparent 75%, rgba(255, 255, 255, 0.08) 75%);
+        background-size: 22px 22px;
+        background-position: 0 0, 0 11px, 11px -11px, -11px 0;
+        opacity: 0.6;
+        pointer-events: none;
+      }
+
+      .drag-banner {
+        position: absolute;
+        inset: 20px;
+        border: 2px dashed rgba(37, 99, 235, 0.58);
+        border-radius: 20px;
+        background: rgba(37, 99, 235, 0.12);
+        display: none;
+        place-items: center;
+        text-align: center;
+        z-index: 5;
+        pointer-events: none;
+        padding: 20px;
+      }
+
+      body.dragging .drag-banner {
+        display: grid;
+      }
+
+      .drag-banner strong {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 1.05rem;
+      }
+
+      .drag-banner p {
+        margin: 0;
+        color: var(--muted);
+      }
+
+      .empty-state {
+        position: relative;
+        z-index: 1;
+        max-width: 420px;
+        padding: 26px;
+        border-radius: 20px;
+        border: 1px solid var(--border);
+        background: rgba(255, 255, 255, 0.08);
+        box-shadow: var(--wt-shadow-sm);
+        text-align: center;
+      }
+
+      .empty-state h3 {
+        margin: 0 0 8px;
+        font-size: 1.2rem;
+      }
+
+      .empty-state p {
+        margin: 0;
+        color: var(--muted);
+      }
+
+      .stage-inner {
+        position: relative;
+        flex: 0 0 auto;
+      }
+
+      .preview-canvas {
+        display: block;
+        box-shadow: 0 20px 40px rgba(2, 6, 23, 0.22);
+        background: transparent;
+        user-select: none;
+      }
+
+      .crop-layer {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+      }
+
+      .crop-layer.active {
+        pointer-events: auto;
+        cursor: crosshair;
+      }
+
+      .crop-layer.active.has-crop {
+        cursor: default;
+      }
+
+      .crop-box {
+        position: absolute;
+        border: 2px solid rgba(255, 255, 255, 0.98);
+        box-shadow:
+          0 0 0 1px rgba(37, 99, 235, 0.92),
+          0 0 0 9999px rgba(7, 11, 22, 0.45);
+        cursor: move;
+      }
+
+      .crop-box.passive {
+        cursor: default;
+      }
+
+      .crop-box[hidden] {
+        display: none;
+      }
+
+      .crop-box::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background:
+          linear-gradient(to right, rgba(255, 255, 255, 0.18) 1px, transparent 1px),
+          linear-gradient(to bottom, rgba(255, 255, 255, 0.18) 1px, transparent 1px);
+        background-size: calc(100% / 3) 100%, 100% calc(100% / 3);
+        pointer-events: none;
+      }
+
+      .crop-handle {
+        position: absolute;
+        width: 14px;
+        height: 14px;
+        border-radius: 999px;
+        background: #fff;
+        border: 2px solid rgba(37, 99, 235, 0.95);
+        box-shadow: 0 0 0 1px rgba(7, 11, 22, 0.12);
+      }
+
+      .crop-box.passive .crop-handle {
+        display: none;
+      }
+
+      .crop-handle[data-handle='nw'] {
+        top: -7px;
+        left: -7px;
+        cursor: nwse-resize;
+      }
+
+      .crop-handle[data-handle='n'] {
+        top: -7px;
+        left: calc(50% - 7px);
+        cursor: ns-resize;
+      }
+
+      .crop-handle[data-handle='ne'] {
+        top: -7px;
+        right: -7px;
+        cursor: nesw-resize;
+      }
+
+      .crop-handle[data-handle='e'] {
+        top: calc(50% - 7px);
+        right: -7px;
+        cursor: ew-resize;
+      }
+
+      .crop-handle[data-handle='se'] {
+        right: -7px;
+        bottom: -7px;
+        cursor: nwse-resize;
+      }
+
+      .crop-handle[data-handle='s'] {
+        bottom: -7px;
+        left: calc(50% - 7px);
+        cursor: ns-resize;
+      }
+
+      .crop-handle[data-handle='sw'] {
+        left: -7px;
+        bottom: -7px;
+        cursor: nesw-resize;
+      }
+
+      .crop-handle[data-handle='w'] {
+        top: calc(50% - 7px);
+        left: -7px;
+        cursor: ew-resize;
+      }
+
+      .stage-toolbar {
+        padding: 12px 14px;
+        border-top: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        flex-wrap: wrap;
+      }
+
+      .stage-toolbar strong {
+        font-size: 0.88rem;
+        color: var(--muted);
+        font-weight: 600;
+        margin-right: 6px;
+      }
+
+      .toolbar-group {
+        display: flex;
+        align-items: center;
+        gap: 8px 12px;
+        flex-wrap: wrap;
+      }
+
+      .toolbar-group span {
+        font-size: 0.92rem;
+        font-variant-numeric: tabular-nums;
+      }
+
+      [hidden] {
+        display: none !important;
+      }
+
+      @media (max-width: 1100px) {
+        .workspace {
+          grid-template-columns: 1fr;
+        }
+
+        .stage-panel {
+          min-height: 620px;
+        }
+      }
+
+      @media (max-width: 720px) {
+        .hero,
+        .panel-body,
+        .stage-head,
+        .stage-toolbar {
+          padding-left: 12px;
+          padding-right: 12px;
+        }
+
+        .meta-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .stage-panel {
+          min-height: 500px;
+        }
+
+        .stage-surface {
+          padding: 18px;
+        }
+
+        .select-row,
+        .scale-row {
+          grid-template-columns: 1fr;
+        }
+
+        .scale-label,
+        .value-label {
+          text-align: left;
+        }
+      }
+    </style>
+  </head>
+  <body class="wt" data-wt-tool="image-editor" data-wt-title="Image Editor">
+    <div class="wt-header" role="banner"></div>
+
+    <main class="wt-page page">
+      <section class="hero">
+        <h1>Image Editor</h1>
+        <p>
+          Paste an image from your clipboard or drag a file into the browser, then zoom in,
+          rotate it, crop it, and export the edited result as PNG or JPG.
+        </p>
+        <div class="hero-list" aria-hidden="true">
+          <span>Clipboard paste</span>
+          <span>Drag and drop</span>
+          <span>Zoom and rotate</span>
+          <span>Freeform crop</span>
+          <span>PNG and JPG export</span>
+        </div>
+      </section>
+
+      <section class="workspace">
+        <aside class="controls">
+          <section class="panel">
+            <div class="panel-head">
+              <h2>Import</h2>
+            </div>
+            <div class="panel-body">
+              <input id="fileInput" type="file" accept="image/*" hidden />
+              <button id="dropZone" class="drop-zone" type="button">
+                <span>
+                  <strong>Drop an image here</strong>
+                  <p>or click to choose a file. You can also paste directly on this page.</p>
+                </span>
+              </button>
+              <div class="btn-row">
+                <button id="clearImageButton" class="wt-btn wt-btn-ghost" type="button">Clear Image</button>
+              </div>
+              <p class="hint">Supported by your browser's image decoder. One image is loaded at a time.</p>
+              <div class="meta-grid">
+                <div class="meta-item">
+                  <strong>File</strong>
+                  <span id="metaName">No image loaded</span>
+                </div>
+                <div class="meta-item">
+                  <strong>Type</strong>
+                  <span id="metaType">-</span>
+                </div>
+                <div class="meta-item">
+                  <strong>Original Size</strong>
+                  <span id="metaOriginalSize">-</span>
+                </div>
+                <div class="meta-item">
+                  <strong>Current Output</strong>
+                  <span id="metaOutputSize">-</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="panel">
+            <div class="panel-head">
+              <h2>Adjust</h2>
+            </div>
+            <div class="panel-body control-stack">
+              <div class="field">
+                <div class="field-header">Zoom</div>
+                <div class="toolbar-row">
+                  <button id="zoomOutButton" class="wt-btn" type="button">Zoom Out</button>
+                  <button id="zoomResetButton" class="wt-btn" type="button">Reset View</button>
+                  <button id="zoomInButton" class="wt-btn" type="button">Zoom In</button>
+                </div>
+                <p class="meta-note">Mouse wheel over the preview also zooms the viewport.</p>
+              </div>
+
+              <div class="field">
+                <div class="field-header">Rotate</div>
+                <div class="toolbar-row">
+                  <button id="rotateLeftButton" class="wt-btn" type="button">Rotate Left</button>
+                  <button id="rotateRightButton" class="wt-btn" type="button">Rotate Right</button>
+                </div>
+              </div>
+
+              <div class="field">
+                <div class="field-header">Crop</div>
+                <div class="toolbar-row">
+                  <button id="cropToggleButton" class="wt-btn" type="button">Start Crop</button>
+                  <button id="clearCropButton" class="wt-btn wt-btn-ghost" type="button">Clear Crop</button>
+                </div>
+                <p class="meta-note">Drag on the image to create a crop box. Press Escape to cancel crop edits.</p>
+              </div>
+
+              <div class="field">
+                <div class="field-header">Reset</div>
+                <div class="toolbar-row">
+                  <button id="resetEditsButton" class="wt-btn wt-btn-ghost" type="button">Reset All Edits</button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section class="panel">
+            <div class="panel-head">
+              <h2>Export</h2>
+            </div>
+            <div class="panel-body">
+              <div class="field">
+                <label for="exportFormat">Format</label>
+                <select id="exportFormat" class="wt-select">
+                  <option value="png">PNG</option>
+                  <option value="jpg">JPG</option>
+                </select>
+              </div>
+
+              <div id="qualityField" class="field" hidden>
+                <div class="scale-row">
+                  <div class="range-wrap">
+                    <label for="exportQuality">JPG Quality</label>
+                    <input id="exportQuality" type="range" min="0.5" max="1" step="0.01" value="0.92" />
+                  </div>
+                  <div id="qualityValue" class="value-label">92%</div>
+                </div>
+                <p class="meta-note">Transparent areas are flattened onto a white background for JPG export.</p>
+              </div>
+
+              <div class="field">
+                <div class="field-header">Download</div>
+                <button id="exportButton" class="wt-btn wt-btn-primary" type="button">Download Edited Image</button>
+              </div>
+            </div>
+          </section>
+        </aside>
+
+        <section class="stage-panel">
+          <div class="stage-head">
+            <h2>Preview</h2>
+            <div id="status" class="status" data-kind="info">Paste or drop an image to start editing.</div>
+          </div>
+
+          <div id="stageViewport" class="stage-viewport">
+            <div class="checkerboard" aria-hidden="true"></div>
+            <div class="drag-banner" aria-hidden="true">
+              <div>
+                <strong>Drop image to load</strong>
+                <p>Release the file anywhere over the editor.</p>
+              </div>
+            </div>
+            <div class="stage-surface">
+              <div id="emptyState" class="empty-state">
+                <h3>Ready for clipboard or drag-and-drop</h3>
+                <p>
+                  Load one image, inspect it with zoom, rotate in 90 degree steps, crop a rectangle,
+                  and export the result as PNG or JPG.
+                </p>
+              </div>
+
+              <div id="stageInner" class="stage-inner" hidden>
+                <canvas id="previewCanvas" class="preview-canvas"></canvas>
+                <div id="cropLayer" class="crop-layer" aria-label="Crop selection layer">
+                  <div id="cropBox" class="crop-box passive" hidden>
+                    <span class="crop-handle" data-handle="nw"></span>
+                    <span class="crop-handle" data-handle="n"></span>
+                    <span class="crop-handle" data-handle="ne"></span>
+                    <span class="crop-handle" data-handle="e"></span>
+                    <span class="crop-handle" data-handle="se"></span>
+                    <span class="crop-handle" data-handle="s"></span>
+                    <span class="crop-handle" data-handle="sw"></span>
+                    <span class="crop-handle" data-handle="w"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="stage-toolbar">
+            <div class="toolbar-group">
+              <strong>Zoom</strong>
+              <span id="zoomValue">100%</span>
+            </div>
+            <div class="toolbar-group">
+              <strong>Rotation</strong>
+              <span id="rotationValue">0 deg</span>
+            </div>
+            <div class="toolbar-group">
+              <strong>Crop</strong>
+              <span id="cropValue">None</span>
+            </div>
+          </div>
+        </section>
+      </section>
+    </main>
+
+    <script>
+      (function () {
+        const MAX_IMAGE_EDGE = 12000;
+        const MAX_IMAGE_PIXELS = 60_000_000;
+        const MIN_CROP_SIZE = 4;
+        const ZOOM_MIN = 0.25;
+        const ZOOM_MAX = 8;
+        const VIEWPORT_PADDING = 56;
+
+        const fileInput = document.getElementById('fileInput');
+        const dropZone = document.getElementById('dropZone');
+        const clearImageButton = document.getElementById('clearImageButton');
+        const zoomOutButton = document.getElementById('zoomOutButton');
+        const zoomResetButton = document.getElementById('zoomResetButton');
+        const zoomInButton = document.getElementById('zoomInButton');
+        const rotateLeftButton = document.getElementById('rotateLeftButton');
+        const rotateRightButton = document.getElementById('rotateRightButton');
+        const cropToggleButton = document.getElementById('cropToggleButton');
+        const clearCropButton = document.getElementById('clearCropButton');
+        const resetEditsButton = document.getElementById('resetEditsButton');
+        const exportFormat = document.getElementById('exportFormat');
+        const exportQuality = document.getElementById('exportQuality');
+        const qualityField = document.getElementById('qualityField');
+        const qualityValue = document.getElementById('qualityValue');
+        const exportButton = document.getElementById('exportButton');
+        const status = document.getElementById('status');
+
+        const metaName = document.getElementById('metaName');
+        const metaType = document.getElementById('metaType');
+        const metaOriginalSize = document.getElementById('metaOriginalSize');
+        const metaOutputSize = document.getElementById('metaOutputSize');
+        const zoomValue = document.getElementById('zoomValue');
+        const rotationValue = document.getElementById('rotationValue');
+        const cropValue = document.getElementById('cropValue');
+
+        const stageViewport = document.getElementById('stageViewport');
+        const emptyState = document.getElementById('emptyState');
+        const stageInner = document.getElementById('stageInner');
+        const previewCanvas = document.getElementById('previewCanvas');
+        const cropLayer = document.getElementById('cropLayer');
+        const cropBox = document.getElementById('cropBox');
+
+        const previewContext = previewCanvas.getContext('2d');
+        if (!previewContext) {
+          setStatus('Canvas rendering is not available in this browser.', 'error');
+          return;
+        }
+
+        const state = {
+          image: null,
+          objectUrl: '',
+          fileName: '',
+          fileType: '',
+          sourceWidth: 0,
+          sourceHeight: 0,
+          rotation: 0,
+          zoom: 1,
+          crop: null,
+          cropMode: false,
+          cropSnapshot: null,
+          rotatedCanvas: null,
+          rotatedWidth: 0,
+          rotatedHeight: 0,
+        };
+
+        let dragDepth = 0;
+        let cropInteraction = null;
+
+        dropZone.addEventListener('click', () => fileInput.click());
+        fileInput.addEventListener('change', async () => {
+          const file = fileInput.files && fileInput.files[0];
+          if (!file) return;
+          await loadFile(file, 'file');
+          fileInput.value = '';
+        });
+
+        clearImageButton.addEventListener('click', () => {
+          clearImage();
+          setStatus('Image cleared.', 'info');
+        });
+
+        zoomInButton.addEventListener('click', () => changeZoom(1.2));
+        zoomOutButton.addEventListener('click', () => changeZoom(1 / 1.2));
+        zoomResetButton.addEventListener('click', () => {
+          if (!hasImage()) return;
+          state.zoom = 1;
+          renderPreview();
+          setStatus('View reset to fit.', 'info');
+        });
+
+        rotateLeftButton.addEventListener('click', () => rotateBy(-90));
+        rotateRightButton.addEventListener('click', () => rotateBy(90));
+
+        cropToggleButton.addEventListener('click', () => {
+          if (!hasImage()) return;
+          if (state.cropMode) {
+            finishCropMode();
+            return;
+          }
+          beginCropMode();
+        });
+
+        clearCropButton.addEventListener('click', () => {
+          if (!state.crop) return;
+          state.crop = null;
+          if (state.cropMode) state.cropSnapshot = null;
+          renderPreview();
+          setStatus('Crop selection cleared.', 'info');
+        });
+
+        resetEditsButton.addEventListener('click', () => {
+          if (!hasImage()) return;
+          state.rotation = 0;
+          state.zoom = 1;
+          state.crop = null;
+          state.cropMode = false;
+          state.cropSnapshot = null;
+          cropInteraction = null;
+          rebuildRotatedCanvas();
+          renderPreview();
+          setStatus('All edits reset.', 'info');
+        });
+
+        exportFormat.addEventListener('change', () => {
+          updateExportUi();
+          updateMeta();
+          updateControls();
+        });
+
+        exportQuality.addEventListener('input', () => {
+          qualityValue.textContent = `${Math.round(Number(exportQuality.value) * 100)}%`;
+        });
+
+        exportButton.addEventListener('click', async () => {
+          await exportImage();
+        });
+
+        cropLayer.addEventListener('pointerdown', onCropPointerDown);
+        cropLayer.addEventListener('pointermove', onCropPointerMove);
+        cropLayer.addEventListener('pointerup', onCropPointerUp);
+        cropLayer.addEventListener('pointercancel', onCropPointerUp);
+
+        stageViewport.addEventListener(
+          'wheel',
+          (event) => {
+            if (!hasImage()) return;
+            if (!isPointerInsideStage(event)) return;
+            event.preventDefault();
+            changeZoom(event.deltaY > 0 ? 1 / 1.1 : 1.1);
+          },
+          { passive: false },
+        );
+
+        document.addEventListener('paste', async (event) => {
+          const items = Array.from(event.clipboardData?.items || []);
+          const item = items.find((entry) => entry.kind === 'file' && entry.type.startsWith('image/'));
+          if (!item) {
+            setStatus('Clipboard does not contain an image file.', 'warning');
+            return;
+          }
+          const file = item.getAsFile();
+          if (!file) {
+            setStatus('Clipboard image could not be read.', 'error');
+            return;
+          }
+          event.preventDefault();
+          await loadFile(file, 'clipboard');
+        });
+
+        window.addEventListener('dragenter', (event) => {
+          if (!hasFilePayload(event.dataTransfer)) return;
+          dragDepth += 1;
+          document.body.classList.add('dragging');
+        });
+
+        window.addEventListener('dragover', (event) => {
+          if (!hasFilePayload(event.dataTransfer)) return;
+          event.preventDefault();
+          dropZone.classList.add('drag-over');
+        });
+
+        window.addEventListener('dragleave', (event) => {
+          if (!hasFilePayload(event.dataTransfer)) return;
+          dragDepth = Math.max(0, dragDepth - 1);
+          if (dragDepth === 0) {
+            document.body.classList.remove('dragging');
+            dropZone.classList.remove('drag-over');
+          }
+        });
+
+        window.addEventListener('drop', async (event) => {
+          if (!hasFilePayload(event.dataTransfer)) return;
+          event.preventDefault();
+          dragDepth = 0;
+          document.body.classList.remove('dragging');
+          dropZone.classList.remove('drag-over');
+          const file = getFirstFile(event.dataTransfer);
+          if (!file) {
+            setStatus('No file was dropped.', 'warning');
+            return;
+          }
+          await loadFile(file, 'drop');
+        });
+
+        window.addEventListener('keydown', (event) => {
+          if (event.key !== 'Escape' || !state.cropMode) return;
+          event.preventDefault();
+          state.crop = cloneRect(state.cropSnapshot);
+          state.cropMode = false;
+          state.cropSnapshot = null;
+          cropInteraction = null;
+          renderPreview();
+          setStatus('Crop changes canceled.', 'info');
+        });
+
+        window.addEventListener('resize', () => {
+          if (!hasImage()) return;
+          renderPreview();
+        });
+
+        updateExportUi();
+        updateMeta();
+        updateControls();
+        qualityValue.textContent = `${Math.round(Number(exportQuality.value) * 100)}%`;
+
+        function hasImage() {
+          return !!state.image && !!state.rotatedCanvas;
+        }
+
+        function setStatus(message, kind) {
+          status.textContent = message;
+          status.dataset.kind = kind || 'info';
+        }
+
+        function updateControls() {
+          const imageLoaded = hasImage();
+          const cropActive = state.cropMode;
+
+          clearImageButton.disabled = !imageLoaded;
+          zoomOutButton.disabled = !imageLoaded;
+          zoomResetButton.disabled = !imageLoaded;
+          zoomInButton.disabled = !imageLoaded;
+          rotateLeftButton.disabled = !imageLoaded || cropActive;
+          rotateRightButton.disabled = !imageLoaded || cropActive;
+          cropToggleButton.disabled = !imageLoaded;
+          clearCropButton.disabled = !imageLoaded || !state.crop;
+          resetEditsButton.disabled = !imageLoaded;
+          exportFormat.disabled = !imageLoaded;
+          exportQuality.disabled = !imageLoaded || exportFormat.value !== 'jpg';
+          exportButton.disabled = !imageLoaded;
+
+          cropToggleButton.textContent = state.cropMode
+            ? 'Done Cropping'
+            : state.crop
+              ? 'Adjust Crop'
+              : 'Start Crop';
+
+          cropLayer.classList.toggle('active', state.cropMode);
+          cropLayer.classList.toggle('has-crop', !!state.crop);
+          cropBox.classList.toggle('passive', !state.cropMode);
+        }
+
+        function updateExportUi() {
+          const jpg = exportFormat.value === 'jpg';
+          qualityField.hidden = !jpg;
+        }
+
+        function updateMeta() {
+          metaName.textContent = state.fileName || 'No image loaded';
+          metaType.textContent = state.fileType || '-';
+          metaOriginalSize.textContent = state.sourceWidth && state.sourceHeight
+            ? `${state.sourceWidth} x ${state.sourceHeight}`
+            : '-';
+
+          const outputRect = getExportRect();
+          metaOutputSize.textContent = outputRect
+            ? `${Math.max(1, Math.round(outputRect.w))} x ${Math.max(1, Math.round(outputRect.h))}`
+            : '-';
+
+          const scale = getDisplayScale();
+          zoomValue.textContent = hasImage() ? `${Math.round(scale * 100)}%` : '100%';
+          rotationValue.textContent = `${state.rotation} deg`;
+          cropValue.textContent = state.crop
+            ? `${Math.round(state.crop.w)} x ${Math.round(state.crop.h)}`
+            : 'None';
+        }
+
+        function clearImage() {
+          revokeObjectUrl();
+          dropZone.classList.remove('drag-over');
+          document.body.classList.remove('dragging');
+          state.image = null;
+          state.fileName = '';
+          state.fileType = '';
+          state.sourceWidth = 0;
+          state.sourceHeight = 0;
+          state.rotation = 0;
+          state.zoom = 1;
+          state.crop = null;
+          state.cropMode = false;
+          state.cropSnapshot = null;
+          state.rotatedCanvas = null;
+          state.rotatedWidth = 0;
+          state.rotatedHeight = 0;
+          cropInteraction = null;
+          previewCanvas.width = 0;
+          previewCanvas.height = 0;
+          renderPreview();
+        }
+
+        function revokeObjectUrl() {
+          if (!state.objectUrl) return;
+          URL.revokeObjectURL(state.objectUrl);
+          state.objectUrl = '';
+        }
+
+        async function loadFile(file, source) {
+          if (!looksLikeImage(file)) {
+            setStatus('Only image files can be loaded into the editor.', 'error');
+            return;
+          }
+
+          const nextUrl = URL.createObjectURL(file);
+          try {
+            const image = await loadImage(nextUrl);
+            if (image.naturalWidth > MAX_IMAGE_EDGE || image.naturalHeight > MAX_IMAGE_EDGE) {
+              throw new Error(`Image exceeds ${MAX_IMAGE_EDGE}px on one edge.`);
+            }
+            if (image.naturalWidth * image.naturalHeight > MAX_IMAGE_PIXELS) {
+              throw new Error('Image is too large for reliable browser editing.');
+            }
+
+            revokeObjectUrl();
+            state.objectUrl = nextUrl;
+            state.image = image;
+            state.fileName = file.name || inferClipboardName(file.type);
+            state.fileType = file.type || 'image/*';
+            state.sourceWidth = image.naturalWidth;
+            state.sourceHeight = image.naturalHeight;
+            state.rotation = 0;
+            state.zoom = 1;
+            state.crop = null;
+            state.cropMode = false;
+            state.cropSnapshot = null;
+            cropInteraction = null;
+            rebuildRotatedCanvas();
+            renderPreview();
+            setStatus(
+              source === 'clipboard'
+                ? 'Clipboard image loaded.'
+                : source === 'drop'
+                  ? 'Dropped image loaded.'
+                  : 'Image loaded.',
+              'success',
+            );
+          } catch (error) {
+            URL.revokeObjectURL(nextUrl);
+            setStatus(error instanceof Error ? error.message : 'Failed to load image.', 'error');
+          }
+        }
+
+        function looksLikeImage(file) {
+          if (file.type) return file.type.startsWith('image/');
+          return /\.(png|jpe?g|gif|webp|bmp|svg|avif|heic|heif)$/i.test(file.name || '');
+        }
+
+        function inferClipboardName(type) {
+          if (!type) return 'clipboard-image.png';
+          const subtype = type.split('/')[1] || 'png';
+          return `clipboard-image.${subtype.replace(/[^a-z0-9]+/gi, '') || 'png'}`;
+        }
+
+        function loadImage(url) {
+          return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.decoding = 'async';
+            image.onload = () => resolve(image);
+            image.onerror = () => reject(new Error('Browser could not decode that image.'));
+            image.src = url;
+          });
+        }
+
+        function rebuildRotatedCanvas() {
+          if (!state.image) return;
+          const canvas = document.createElement('canvas');
+          const quarterTurns = state.rotation / 90;
+          const swap = Math.abs(quarterTurns % 2) === 1;
+          canvas.width = swap ? state.sourceHeight : state.sourceWidth;
+          canvas.height = swap ? state.sourceWidth : state.sourceHeight;
+
+          const context = canvas.getContext('2d');
+          if (!context) {
+            throw new Error('Canvas rendering is not available in this browser.');
+          }
+          context.imageSmoothingEnabled = true;
+          context.imageSmoothingQuality = 'high';
+
+          switch (state.rotation) {
+            case 90:
+              context.translate(canvas.width, 0);
+              context.rotate(Math.PI / 2);
+              break;
+            case 180:
+              context.translate(canvas.width, canvas.height);
+              context.rotate(Math.PI);
+              break;
+            case 270:
+              context.translate(0, canvas.height);
+              context.rotate(-Math.PI / 2);
+              break;
+            default:
+              break;
+          }
+
+          context.drawImage(state.image, 0, 0);
+          state.rotatedCanvas = canvas;
+          state.rotatedWidth = canvas.width;
+          state.rotatedHeight = canvas.height;
+
+          previewCanvas.width = canvas.width;
+          previewCanvas.height = canvas.height;
+          previewContext.clearRect(0, 0, canvas.width, canvas.height);
+          previewContext.drawImage(canvas, 0, 0);
+        }
+
+        function getDisplayScale() {
+          if (!hasImage()) return 1;
+          const availableWidth = Math.max(120, stageViewport.clientWidth - VIEWPORT_PADDING);
+          const availableHeight = Math.max(120, stageViewport.clientHeight - VIEWPORT_PADDING);
+          const fitScale = Math.min(
+            1,
+            availableWidth / state.rotatedWidth,
+            availableHeight / state.rotatedHeight,
+          );
+          return fitScale * state.zoom;
+        }
+
+        function renderPreview() {
+          const imageLoaded = hasImage();
+          emptyState.hidden = imageLoaded;
+          stageInner.hidden = !imageLoaded;
+
+          if (!imageLoaded) {
+            cropBox.hidden = true;
+            updateMeta();
+            updateControls();
+            return;
+          }
+
+          const scale = getDisplayScale();
+          const displayWidth = Math.max(1, Math.round(state.rotatedWidth * scale));
+          const displayHeight = Math.max(1, Math.round(state.rotatedHeight * scale));
+
+          stageInner.style.width = `${displayWidth}px`;
+          stageInner.style.height = `${displayHeight}px`;
+          previewCanvas.style.width = `${displayWidth}px`;
+          previewCanvas.style.height = `${displayHeight}px`;
+
+          updateCropBox();
+          updateMeta();
+          updateControls();
+        }
+
+        function changeZoom(multiplier) {
+          if (!hasImage()) return;
+          state.zoom = clamp(state.zoom * multiplier, ZOOM_MIN, ZOOM_MAX);
+          renderPreview();
+        }
+
+        function rotateBy(delta) {
+          if (!hasImage() || state.cropMode) return;
+          const oldWidth = state.rotatedWidth;
+          const oldHeight = state.rotatedHeight;
+          state.rotation = normalizeRotation(state.rotation + delta);
+          if (state.crop) {
+            state.crop = rotateCropRect(state.crop, oldWidth, oldHeight, delta);
+          }
+          rebuildRotatedCanvas();
+          renderPreview();
+          setStatus(delta > 0 ? 'Rotated clockwise.' : 'Rotated counterclockwise.', 'success');
+        }
+
+        function normalizeRotation(value) {
+          const next = value % 360;
+          return next < 0 ? next + 360 : next;
+        }
+
+        function rotateCropRect(rect, width, height, delta) {
+          const normalized = normalizeRotation(delta);
+          if (normalized === 90) {
+            return {
+              x: height - (rect.y + rect.h),
+              y: rect.x,
+              w: rect.h,
+              h: rect.w,
+            };
+          }
+          if (normalized === 180) {
+            return {
+              x: width - (rect.x + rect.w),
+              y: height - (rect.y + rect.h),
+              w: rect.w,
+              h: rect.h,
+            };
+          }
+          if (normalized === 270) {
+            return {
+              x: rect.y,
+              y: width - (rect.x + rect.w),
+              w: rect.h,
+              h: rect.w,
+            };
+          }
+          return cloneRect(rect);
+        }
+
+        function beginCropMode() {
+          state.cropMode = true;
+          state.cropSnapshot = cloneRect(state.crop);
+          cropInteraction = null;
+          renderPreview();
+          setStatus(
+            state.crop
+              ? 'Adjust the crop box, then choose Done Cropping.'
+              : 'Drag on the image to create a crop box.',
+            'info',
+          );
+        }
+
+        function finishCropMode() {
+          state.cropMode = false;
+          state.cropSnapshot = null;
+          cropInteraction = null;
+          renderPreview();
+          setStatus(state.crop ? 'Crop selection saved.' : 'Crop mode closed.', 'success');
+        }
+
+        function onCropPointerDown(event) {
+          if (!state.cropMode || !hasImage()) return;
+          if (!previewCanvas.contains(event.target) && !cropLayer.contains(event.target)) return;
+
+          const point = pointerToImagePoint(event);
+          if (!point) return;
+
+          const handle = event.target instanceof HTMLElement ? event.target.dataset.handle : '';
+          if (handle && state.crop) {
+            cropInteraction = {
+              kind: 'resize',
+              handle,
+              startCrop: cloneRect(state.crop),
+              pointerId: event.pointerId,
+            };
+          } else if (state.crop && event.target === cropBox) {
+            cropInteraction = {
+              kind: 'move',
+              startCrop: cloneRect(state.crop),
+              startPoint: point,
+              pointerId: event.pointerId,
+            };
+          } else {
+            state.crop = { x: point.x, y: point.y, w: 0, h: 0 };
+            cropInteraction = {
+              kind: 'create',
+              startPoint: point,
+              pointerId: event.pointerId,
+            };
+          }
+
+          cropLayer.setPointerCapture(event.pointerId);
+          event.preventDefault();
+          updateCropBox();
+          updateMeta();
+          updateControls();
+        }
+
+        function onCropPointerMove(event) {
+          if (!cropInteraction || !state.cropMode || !hasImage()) return;
+          if (event.pointerId !== cropInteraction.pointerId) return;
+          const point = pointerToImagePoint(event);
+          if (!point) return;
+
+          if (cropInteraction.kind === 'create') {
+            const x1 = clamp(Math.min(cropInteraction.startPoint.x, point.x), 0, state.rotatedWidth);
+            const y1 = clamp(Math.min(cropInteraction.startPoint.y, point.y), 0, state.rotatedHeight);
+            const x2 = clamp(Math.max(cropInteraction.startPoint.x, point.x), 0, state.rotatedWidth);
+            const y2 = clamp(Math.max(cropInteraction.startPoint.y, point.y), 0, state.rotatedHeight);
+            state.crop = { x: x1, y: y1, w: x2 - x1, h: y2 - y1 };
+          } else if (cropInteraction.kind === 'move') {
+            const dx = point.x - cropInteraction.startPoint.x;
+            const dy = point.y - cropInteraction.startPoint.y;
+            const startCrop = cropInteraction.startCrop;
+            const nextX = clamp(startCrop.x + dx, 0, state.rotatedWidth - startCrop.w);
+            const nextY = clamp(startCrop.y + dy, 0, state.rotatedHeight - startCrop.h);
+            state.crop = { x: nextX, y: nextY, w: startCrop.w, h: startCrop.h };
+          } else if (cropInteraction.kind === 'resize') {
+            const next = resizeCropRect(cropInteraction.startCrop, cropInteraction.handle, point);
+            state.crop = next;
+          }
+
+          updateCropBox();
+          updateMeta();
+        }
+
+        function onCropPointerUp(event) {
+          if (!cropInteraction) return;
+          if (event.pointerId !== cropInteraction.pointerId) return;
+
+          if (state.crop && (state.crop.w < MIN_CROP_SIZE || state.crop.h < MIN_CROP_SIZE)) {
+            state.crop = cloneRect(state.cropSnapshot);
+          }
+
+          cropInteraction = null;
+          if (cropLayer.hasPointerCapture(event.pointerId)) {
+            cropLayer.releasePointerCapture(event.pointerId);
+          }
+          updateCropBox();
+          updateMeta();
+          updateControls();
+        }
+
+        function resizeCropRect(startCrop, handle, point) {
+          let left = startCrop.x;
+          let right = startCrop.x + startCrop.w;
+          let top = startCrop.y;
+          let bottom = startCrop.y + startCrop.h;
+
+          if (handle.includes('w')) {
+            left = clamp(point.x, 0, right - MIN_CROP_SIZE);
+          }
+          if (handle.includes('e')) {
+            right = clamp(point.x, left + MIN_CROP_SIZE, state.rotatedWidth);
+          }
+          if (handle.includes('n')) {
+            top = clamp(point.y, 0, bottom - MIN_CROP_SIZE);
+          }
+          if (handle.includes('s')) {
+            bottom = clamp(point.y, top + MIN_CROP_SIZE, state.rotatedHeight);
+          }
+
+          return {
+            x: left,
+            y: top,
+            w: right - left,
+            h: bottom - top,
+          };
+        }
+
+        function pointerToImagePoint(event) {
+          const rect = stageInner.getBoundingClientRect();
+          const scale = getDisplayScale();
+          if (!scale) return null;
+          const x = clamp((event.clientX - rect.left) / scale, 0, state.rotatedWidth);
+          const y = clamp((event.clientY - rect.top) / scale, 0, state.rotatedHeight);
+          return { x, y };
+        }
+
+        function updateCropBox() {
+          if (!hasImage() || !state.crop) {
+            cropBox.hidden = true;
+            return;
+          }
+
+          const scale = getDisplayScale();
+          cropBox.hidden = false;
+          cropBox.style.left = `${state.crop.x * scale}px`;
+          cropBox.style.top = `${state.crop.y * scale}px`;
+          cropBox.style.width = `${Math.max(1, state.crop.w * scale)}px`;
+          cropBox.style.height = `${Math.max(1, state.crop.h * scale)}px`;
+        }
+
+        function getExportRect() {
+          if (!hasImage()) return null;
+          if (!state.crop) {
+            return {
+              x: 0,
+              y: 0,
+              w: state.rotatedWidth,
+              h: state.rotatedHeight,
+            };
+          }
+          return cloneRect(state.crop);
+        }
+
+        async function exportImage() {
+          if (!hasImage()) return;
+          const rect = getExportRect();
+          if (!rect || rect.w < 1 || rect.h < 1) {
+            setStatus('Crop area is empty and cannot be exported.', 'error');
+            return;
+          }
+
+          try {
+            const canvas = document.createElement('canvas');
+            canvas.width = Math.max(1, Math.round(rect.w));
+            canvas.height = Math.max(1, Math.round(rect.h));
+            const context = canvas.getContext('2d');
+            if (!context) throw new Error('Canvas export is not available in this browser.');
+
+            if (exportFormat.value === 'jpg') {
+              context.fillStyle = '#ffffff';
+              context.fillRect(0, 0, canvas.width, canvas.height);
+            } else {
+              context.clearRect(0, 0, canvas.width, canvas.height);
+            }
+
+            context.imageSmoothingEnabled = true;
+            context.imageSmoothingQuality = 'high';
+            context.drawImage(
+              state.rotatedCanvas,
+              rect.x,
+              rect.y,
+              rect.w,
+              rect.h,
+              0,
+              0,
+              canvas.width,
+              canvas.height,
+            );
+
+            const mimeType = exportFormat.value === 'jpg' ? 'image/jpeg' : 'image/png';
+            const quality = exportFormat.value === 'jpg' ? Number(exportQuality.value) : undefined;
+            const blob = await canvasToBlob(canvas, mimeType, quality);
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = buildDownloadName(exportFormat.value);
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            setTimeout(() => URL.revokeObjectURL(url), 1500);
+            setStatus(`Exported ${canvas.width} x ${canvas.height} ${exportFormat.value.toUpperCase()}.`, 'success');
+          } catch (error) {
+            setStatus(error instanceof Error ? error.message : 'Failed to export image.', 'error');
+          }
+        }
+
+        function buildDownloadName(format) {
+          const base = (state.fileName || 'image')
+            .replace(/\.[^.]+$/, '')
+            .replace(/[^\w.-]+/g, '-')
+            .replace(/^-+|-+$/g, '') || 'image';
+          return `${base}-edited.${format}`;
+        }
+
+        function canvasToBlob(canvas, mimeType, quality) {
+          return new Promise((resolve, reject) => {
+            canvas.toBlob(
+              (blob) => {
+                if (!blob) {
+                  reject(new Error('Browser returned an empty export.'));
+                  return;
+                }
+                resolve(blob);
+              },
+              mimeType,
+              quality,
+            );
+          });
+        }
+
+        function cloneRect(rect) {
+          return rect ? { x: rect.x, y: rect.y, w: rect.w, h: rect.h } : null;
+        }
+
+        function clamp(value, min, max) {
+          return Math.min(max, Math.max(min, value));
+        }
+
+        function hasFilePayload(dataTransfer) {
+          if (!dataTransfer) return false;
+          if (Array.from(dataTransfer.items || []).some((item) => item.kind === 'file')) return true;
+          return Array.from(dataTransfer.types || []).includes('Files');
+        }
+
+        function getFirstFile(dataTransfer) {
+          if (!dataTransfer) return null;
+          if (dataTransfer.files && dataTransfer.files[0]) return dataTransfer.files[0];
+          const item = Array.from(dataTransfer.items || []).find((entry) => entry.kind === 'file');
+          return item ? item.getAsFile() : null;
+        }
+
+        function isPointerInsideStage(event) {
+          const rect = stageViewport.getBoundingClientRect();
+          return (
+            event.clientX >= rect.left &&
+            event.clientX <= rect.right &&
+            event.clientY >= rect.top &&
+            event.clientY <= rect.bottom
+          );
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -276,6 +276,20 @@
         <p>Encode files to Base64 and decode Base64 strings back into downloadable files.</p>
       </a>
 
+      <a class="tile" href="/image-editor" data-keywords="image editor crop rotate zoom png jpg jpeg clipboard drag drop">
+        <div class="tile-icon">
+          <svg viewBox="0 0 24 24">
+            <path d="M4 5a2 2 0 0 1 2-2h3"></path>
+            <path d="M14 3h4a2 2 0 0 1 2 2v4"></path>
+            <path d="M20 14v5a2 2 0 0 1-2 2h-5"></path>
+            <path d="M10 21H6a2 2 0 0 1-2-2v-4"></path>
+            <path d="M7 15l3-3 2 2 5-5 2 2"></path>
+          </svg>
+        </div>
+        <h2>Image Editor</h2>
+        <p>Paste or drag an image, zoom in, rotate it, crop it, and export PNG or JPG files.</p>
+      </a>
+
       <a class="tile" href="/url-encode-decode" data-keywords="url encode decode uri component percent query">
         <div class="tile-icon">
           <svg viewBox="0 0 24 24">

--- a/public/shared/toolkit.js
+++ b/public/shared/toolkit.js
@@ -7,6 +7,7 @@
     { id: 'pastebin', title: 'Pastebin', href: '/pastebin' },
     { id: 'diff', title: 'Text Diff', href: '/diff' },
     { id: 'base64', title: 'Base64 Encoder/Decoder', href: '/base64' },
+    { id: 'image-editor', title: 'Image Editor', href: '/image-editor' },
     { id: 'url-encode-decode', title: 'URL Encode/Decode', href: '/url-encode-decode' },
     { id: 'format-tools', title: 'Data Format Converter', href: '/format-tools' },
     { id: 'csv-editor', title: 'CSV Viewer & Editor', href: '/csv-editor' },

--- a/src/static.ts
+++ b/src/static.ts
@@ -29,6 +29,8 @@ const PRETTY_ROUTES: Record<string, string> = {
   '/tiff-viewer/': '/tiff-viewer.html',
   '/base64': '/base64.html',
   '/base64/': '/base64.html',
+  '/image-editor': '/image-editor.html',
+  '/image-editor/': '/image-editor.html',
   '/url-encode-decode': '/url-encode-decode.html',
   '/url-encode-decode/': '/url-encode-decode.html',
   '/actuary': '/actuary.html',

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -19,6 +19,7 @@ describe('Tools index and Markdown viewer', () => {
     expect(body).toContain('href="/markdown"');
     expect(body).toContain('href="/diff"');
     expect(body).toContain('href="/base64"');
+    expect(body).toContain('href="/image-editor"');
     expect(body).toContain('href="/url-encode-decode"');
     expect(body).toContain('href="/format-tools"');
     expect(body).toContain('href="/csv-editor"');
@@ -73,6 +74,19 @@ describe('Tools index and Markdown viewer', () => {
     expect(body).toContain('<title>Base64 Encoder/Decoder</title>');
     expect(body).toContain('id="dropZone"');
     expect(body).toContain('id="decodeInput"');
+  });
+
+  it('serves image editor at /image-editor (unit)', async () => {
+    const request = new IncomingRequest('http://example.com/image-editor');
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    const body = await response.text();
+    expect(body).toContain('<title>Image Editor</title>');
+    expect(body).toContain('id="dropZone"');
+    expect(body).toContain('id="exportButton"');
   });
 
   it('serves url encode/decode tool at /url-encode-decode (unit)', async () => {
@@ -140,6 +154,14 @@ describe('Tools index and Markdown viewer', () => {
     expect(response.headers.get('content-type')).toContain('text/html');
     const body = await response.text();
     expect(body).toContain('<title>Base64 Encoder/Decoder</title>');
+  });
+
+  it('serves image editor (integration)', async () => {
+    const response = await SELF.fetch('https://example.com/image-editor');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    const body = await response.text();
+    expect(body).toContain('<title>Image Editor</title>');
   });
 
   it('serves url encode/decode tool (integration)', async () => {


### PR DESCRIPTION
## Summary
- Add a browser-only image editor tool for clipboard paste, drag-and-drop, cropping, rotation, zoom, and PNG/JPG export.

## Changes
- Add a new static `image-editor` page with client-side image loading, 90-degree rotation, freeform crop controls, zoom, and PNG/JPG export.
- Register `/image-editor` in static routing and shared tool navigation, and add a homepage tile for the new tool.
- Extend worker route tests to cover the new page and its homepage link.

## Testing
- `npm test`

## Notes
- The editor is fully client-side and does not add any new worker API or persistence.
- Manual browser verification is still useful for clipboard, drag-and-drop, crop, and export interactions.
