### PR TITLE
Add AVIF export support to image editor

### DIFF
--- a/public/image-editor.html
+++ b/public/image-editor.html
@@ -711,6 +711,7 @@
                   <option value="png">PNG</option>
                   <option value="jpg">JPG</option>
                   <option value="webp">WEBP</option>
+                  <option value="avif">AVIF</option>
                 </select>
               </div>
 
@@ -865,7 +866,7 @@
                 <h3>Ready for clipboard or drag-and-drop</h3>
                 <p>
                   Load one image, inspect it with zoom, rotate in 90 degree steps, crop a rectangle,
-                  scale it by percentage or pixels, and export the result as PNG, JPG, or WEBP.
+                  scale it by percentage or pixels, and export the result as PNG, JPG, WEBP, or AVIF.
                 </p>
               </div>
 
@@ -1224,7 +1225,7 @@
           scalePercentHeight.disabled = !imageLoaded || getScaleMode() !== 'percent';
           scaleWidth.disabled = !imageLoaded || getScaleMode() !== 'pixels';
           scaleHeight.disabled = !imageLoaded || getScaleMode() !== 'pixels';
-          exportQuality.disabled = !imageLoaded || exportFormat.value === 'png';
+          exportQuality.disabled = !imageLoaded || !formatUsesQuality(exportFormat.value);
           exportButton.disabled = !exportReady;
           copyImageButton.disabled = !exportReady || !clipboardSupported;
           clipboardSupportHint.hidden = clipboardSupported;
@@ -1243,7 +1244,7 @@
 
         function updateExportUi() {
           const format = exportFormat.value;
-          const usesQuality = format === 'jpg' || format === 'webp';
+          const usesQuality = formatUsesQuality(format);
           const mode = getScaleMode();
 
           scalePercentField.hidden = mode !== 'percent';
@@ -1259,6 +1260,9 @@
           } else if (format === 'webp') {
             exportQualityLabel.textContent = 'WEBP Quality';
             qualityNote.textContent = 'WEBP export keeps transparency when the browser supports it.';
+          } else if (format === 'avif') {
+            exportQualityLabel.textContent = 'AVIF Quality';
+            qualityNote.textContent = 'AVIF export keeps transparency when the browser supports it.';
           } else {
             exportQualityLabel.textContent = 'Export Quality';
             qualityNote.textContent = '';
@@ -2234,13 +2238,15 @@
             canvas.height,
           );
 
-          const mimeType = format === 'jpg'
-            ? 'image/jpeg'
-            : format === 'webp'
-              ? 'image/webp'
-              : 'image/png';
-          const quality = format === 'png' ? undefined : Number(exportQuality.value);
+          const mimeType = getExportMimeType(format);
+          const quality = formatUsesQuality(format) ? Number(exportQuality.value) : undefined;
           const blob = await canvasToBlob(canvas, mimeType, quality);
+          if (blob.type !== mimeType) {
+            if (format === 'avif') {
+              throw new Error('AVIF export is not supported in this browser.');
+            }
+            throw new Error(`Browser could not encode ${format.toUpperCase()} output.`);
+          }
           return {
             blob,
             format,
@@ -2272,6 +2278,20 @@
               quality,
             );
           });
+        }
+
+        function formatUsesQuality(format) {
+          return format === 'jpg' || format === 'webp' || format === 'avif';
+        }
+
+        function getExportMimeType(format) {
+          return format === 'jpg'
+            ? 'image/jpeg'
+            : format === 'webp'
+              ? 'image/webp'
+              : format === 'avif'
+                ? 'image/avif'
+                : 'image/png';
         }
 
         function supportsImageClipboardWrite() {

--- a/public/index.html
+++ b/public/index.html
@@ -276,7 +276,7 @@
         <p>Encode files to Base64 and decode Base64 strings back into downloadable files.</p>
       </a>
 
-      <a class="tile" href="/image-editor" data-keywords="image editor crop rotate zoom png jpg jpeg clipboard drag drop">
+      <a class="tile" href="/image-editor" data-keywords="image editor crop rotate zoom png jpg jpeg webp avif clipboard drag drop">
         <div class="tile-icon">
           <svg viewBox="0 0 24 24">
             <path d="M4 5a2 2 0 0 1 2-2h3"></path>
@@ -287,7 +287,7 @@
           </svg>
         </div>
         <h2>Image Editor</h2>
-        <p>Paste or drag an image, zoom in, rotate it, crop it, and export PNG or JPG files.</p>
+        <p>Paste or drag an image, zoom in, rotate it, crop it, and export PNG, JPG, WEBP, or AVIF files.</p>
       </a>
 
       <a class="tile" href="/url-encode-decode" data-keywords="url encode decode uri component percent query">

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -96,6 +96,7 @@ describe('Tools index and Markdown viewer', () => {
     expect(body).toContain('id="scaleWidth"');
     expect(body).toContain('id="exportButton"');
     expect(body).toContain('id="copyImageButton"');
+    expect(body).toContain('<option value="avif">AVIF</option>');
   });
 
   it('serves url encode/decode tool at /url-encode-decode (unit)', async () => {
@@ -201,6 +202,7 @@ describe('Tools index and Markdown viewer', () => {
     expect(body).toContain('id="scaleModePixels"');
     expect(body).toContain('id="aspectRatioSelect"');
     expect(body).toContain('id="copyImageButton"');
+    expect(body).toContain('<option value="avif">AVIF</option>');
   });
 
   it('serves url encode/decode tool (integration)', async () => {


### PR DESCRIPTION
## Summary
- Add AVIF export support to the image editor export workflow.

## Changes
- Add AVIF to the image editor export format selector and update the tool copy on the editor page and index tile.
- Route AVIF through the existing canvas export path with quality controls and explicit MIME validation so unsupported browsers fail clearly.
- Extend the image editor page tests to assert that the AVIF export option is present.

## Testing
- `npm test`

## Notes
- AVIF export depends on browser support for `canvas.toBlob('image/avif')` and now returns a clear error when encoding is unavailable.
