### PR TITLE
Add Trello-style boards tool

### DIFF
--- a/migrations/0007_boards.sql
+++ b/migrations/0007_boards.sql
@@ -1,0 +1,56 @@
+-- D1 schema for Boards tool
+-- Uses existing users and sessions tables from 0001_pastebin.sql
+
+CREATE TABLE IF NOT EXISTS boards (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_boards_user_sort ON boards(user_id, sort_order ASC, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS board_lists (
+  id TEXT PRIMARY KEY,
+  board_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_board_lists_board_sort ON board_lists(board_id, sort_order ASC, created_at ASC);
+
+CREATE TABLE IF NOT EXISTS board_cards (
+  id TEXT PRIMARY KEY,
+  board_id TEXT NOT NULL,
+  list_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  markdown TEXT NOT NULL DEFAULT '',
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  FOREIGN KEY (board_id) REFERENCES boards(id) ON DELETE CASCADE,
+  FOREIGN KEY (list_id) REFERENCES board_lists(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_board_cards_list_sort ON board_cards(list_id, sort_order ASC, created_at ASC);
+CREATE INDEX IF NOT EXISTS idx_board_cards_board_list_sort ON board_cards(board_id, list_id, sort_order ASC);
+
+CREATE TABLE IF NOT EXISTS card_images (
+  id TEXT PRIMARY KEY,
+  card_id TEXT NOT NULL,
+  mime_type TEXT NOT NULL,
+  data_url TEXT NOT NULL,
+  alt_text TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+  FOREIGN KEY (card_id) REFERENCES board_cards(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_card_images_card_sort ON card_images(card_id, sort_order ASC, created_at ASC);

--- a/public/boards.html
+++ b/public/boards.html
@@ -754,7 +754,6 @@
         };
 
         const boardListEl = document.getElementById('boardList');
-        const authAreaEl = document.getElementById('authArea');
         const authPanelEl = document.getElementById('authPanel');
         const emptyPanelEl = document.getElementById('emptyPanel');
         const boardPaneEl = document.getElementById('boardPane');
@@ -762,7 +761,6 @@
         const boardTitleEl = document.getElementById('boardTitle');
         const boardDescriptionEl = document.getElementById('boardDescription');
         const statusBarEl = document.getElementById('statusBar');
-        const modePillEl = document.getElementById('modePill');
         const cardModalEl = document.getElementById('cardModal');
         const cardModalTitleEl = document.getElementById('cardModalTitle');
         const cardTitleInputEl = document.getElementById('cardTitleInput');
@@ -815,6 +813,14 @@
           return sanitizeMarkdown(markdown || '');
         }
 
+        function getAuthAreaEl() {
+          return document.getElementById('authArea');
+        }
+
+        function getModePillEl() {
+          return document.getElementById('modePill');
+        }
+
         function formatBoardMeta(board) {
           const pieces = [];
           pieces.push(`${board.list_count || 0} list${board.list_count === 1 ? '' : 's'}`);
@@ -841,6 +847,10 @@
         }
 
         function renderAuthArea() {
+          const authAreaEl = getAuthAreaEl();
+          const modePillEl = getModePillEl();
+          if (!authAreaEl || !modePillEl) return;
+
           authAreaEl.innerHTML = '';
           if (!state.auth.loggedIn) {
             const next = encodeURIComponent(location.pathname + location.search);
@@ -1642,9 +1652,19 @@
           setStatus('Boards ready.');
         }
 
-        boot().catch((error) => {
-          setStatus(error instanceof Error ? error.message : 'Failed to load boards.', 'error');
-        });
+        function startBoot() {
+          requestAnimationFrame(() => {
+            boot().catch((error) => {
+              setStatus(error instanceof Error ? error.message : 'Failed to load boards.', 'error');
+            });
+          });
+        }
+
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', startBoot, { once: true });
+        } else {
+          startBoot();
+        }
       })();
     </script>
   </body>

--- a/public/boards.html
+++ b/public/boards.html
@@ -1,0 +1,1651 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Boards</title>
+    <link rel="stylesheet" href="/shared/toolkit.css" />
+    <script defer src="/shared/toolkit.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.7/dist/purify.min.js"></script>
+    <style>
+      :root {
+        --boards-accent: #d97706;
+        --boards-accent-soft: rgba(217, 119, 6, 0.14);
+        --boards-accent-2: #0f766e;
+        --boards-ink-soft: rgba(15, 23, 42, 0.68);
+        --boards-card-shadow: 0 16px 40px rgba(15, 23, 42, 0.12);
+      }
+
+      [data-theme='dark'] {
+        --boards-accent: #fb923c;
+        --boards-accent-soft: rgba(251, 146, 60, 0.18);
+        --boards-accent-2: #2dd4bf;
+        --boards-ink-soft: rgba(226, 232, 240, 0.72);
+        --boards-card-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        background: transparent;
+      }
+
+      .boards-page {
+        display: grid;
+        grid-template-columns: 300px minmax(0, 1fr);
+        gap: 18px;
+        min-height: calc(100vh - 110px);
+      }
+
+      .panel {
+        border: 1px solid var(--wt-border);
+        border-radius: 24px;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.24), transparent 38%),
+          var(--wt-panel-solid);
+        box-shadow: var(--boards-card-shadow);
+      }
+
+      .sidebar {
+        padding: 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        min-height: 720px;
+      }
+
+      .sidebar-head {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .eyebrow {
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        font-size: 0.72rem;
+        color: var(--boards-accent);
+        font-weight: 800;
+      }
+
+      .sidebar h1 {
+        margin: 0;
+        font-size: 2rem;
+        line-height: 1;
+        letter-spacing: -0.04em;
+      }
+
+      .sidebar-copy {
+        margin: 0;
+        color: var(--boards-ink-soft);
+      }
+
+      .sidebar-actions {
+        display: flex;
+        gap: 10px;
+      }
+
+      .sidebar-actions .wt-btn-primary {
+        background: linear-gradient(135deg, var(--boards-accent), var(--boards-accent-2));
+        border-color: rgba(217, 119, 6, 0.4);
+      }
+
+      .board-list {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        overflow: auto;
+        padding-right: 4px;
+      }
+
+      .board-item {
+        appearance: none;
+        display: block;
+        width: 100%;
+        text-align: left;
+        font: inherit;
+        color: inherit;
+        border: 1px solid var(--wt-border);
+        background: rgba(255, 255, 255, 0.04);
+        border-radius: 18px;
+        padding: 14px 15px;
+        cursor: pointer;
+        transition: transform 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+      }
+
+      .board-item:hover {
+        transform: translateY(-1px);
+        border-color: rgba(217, 119, 6, 0.35);
+      }
+
+      .board-item.active {
+        border-color: rgba(217, 119, 6, 0.46);
+        background: linear-gradient(135deg, var(--boards-accent-soft), rgba(15, 118, 110, 0.08));
+      }
+
+      .board-item h3 {
+        margin: 0 0 6px;
+        font-size: 1rem;
+      }
+
+      .board-item p {
+        margin: 0;
+        color: var(--boards-ink-soft);
+        font-size: 0.92rem;
+      }
+
+      .board-meta {
+        margin-top: 10px;
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .meta-pill {
+        border-radius: 999px;
+        background: rgba(127, 127, 127, 0.12);
+        padding: 5px 9px;
+        font-size: 0.78rem;
+        color: var(--boards-ink-soft);
+      }
+
+      .workspace {
+        min-width: 0;
+        padding: 18px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .workspace-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      .workspace-title h2 {
+        margin: 0;
+        font-size: 2rem;
+        letter-spacing: -0.04em;
+      }
+
+      .workspace-title p {
+        margin: 8px 0 0;
+        color: var(--boards-ink-soft);
+      }
+
+      .workspace-actions {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+
+      .workspace-actions .wt-btn-primary {
+        background: linear-gradient(135deg, var(--boards-accent), var(--boards-accent-2));
+        border-color: rgba(217, 119, 6, 0.4);
+      }
+
+      .auth-panel,
+      .empty-panel {
+        padding: 32px;
+        border-radius: 26px;
+        border: 1px dashed rgba(217, 119, 6, 0.28);
+        background:
+          radial-gradient(circle at top right, rgba(217, 119, 6, 0.12), transparent 30%),
+          radial-gradient(circle at bottom left, rgba(15, 118, 110, 0.1), transparent 34%),
+          rgba(255, 255, 255, 0.05);
+      }
+
+      .auth-panel h3,
+      .empty-panel h3 {
+        margin: 0 0 8px;
+        font-size: 1.5rem;
+      }
+
+      .auth-panel p,
+      .empty-panel p {
+        margin: 0 0 18px;
+        color: var(--boards-ink-soft);
+        max-width: 48rem;
+      }
+
+      .board-canvas {
+        display: flex;
+        gap: 16px;
+        overflow-x: auto;
+        align-items: flex-start;
+        padding: 6px 2px 12px;
+        min-height: 440px;
+      }
+
+      .list-column {
+        width: 320px;
+        min-width: 320px;
+        padding: 14px;
+        border-radius: 22px;
+        border: 1px solid var(--wt-border);
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.16), transparent 34%),
+          rgba(255, 255, 255, 0.04);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+      }
+
+      .list-column.drag-target-before {
+        box-shadow: inset 4px 0 0 var(--boards-accent), var(--boards-card-shadow);
+      }
+
+      .list-column.drag-target-after {
+        box-shadow: inset -4px 0 0 var(--boards-accent), var(--boards-card-shadow);
+      }
+
+      .list-head {
+        display: flex;
+        gap: 12px;
+        align-items: flex-start;
+      }
+
+      .drag-handle {
+        width: 34px;
+        height: 34px;
+        border-radius: 12px;
+        border: 1px dashed var(--wt-border);
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--boards-ink-soft);
+        cursor: grab;
+        flex: 0 0 auto;
+      }
+
+      .list-body {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .list-title-row {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .list-title-row h3 {
+        margin: 0;
+        font-size: 1.05rem;
+      }
+
+      .list-actions {
+        display: flex;
+        gap: 6px;
+        margin-top: 10px;
+      }
+
+      .list-actions .wt-btn {
+        padding: 7px 9px;
+      }
+
+      .card-stack {
+        margin-top: 16px;
+        min-height: 60px;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .card-stack.drag-target {
+        outline: 2px dashed rgba(217, 119, 6, 0.42);
+        outline-offset: 6px;
+        border-radius: 20px;
+      }
+
+      .card-empty {
+        border: 1px dashed var(--wt-border);
+        border-radius: 16px;
+        padding: 15px;
+        text-align: center;
+        color: var(--boards-ink-soft);
+        font-size: 0.92rem;
+      }
+
+      .card-item {
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 18px;
+        padding: 14px 14px 12px;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.24), transparent 38%),
+          var(--wt-panel-solid);
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+      }
+
+      .card-item:hover {
+        transform: translateY(-1px);
+        border-color: rgba(217, 119, 6, 0.26);
+        box-shadow: var(--boards-card-shadow);
+      }
+
+      .card-item.drag-target-before {
+        box-shadow: inset 0 4px 0 var(--boards-accent), var(--boards-card-shadow);
+      }
+
+      .card-item.drag-target-after {
+        box-shadow: inset 0 -4px 0 var(--boards-accent), var(--boards-card-shadow);
+      }
+
+      .card-item.file-target {
+        outline: 2px dashed rgba(15, 118, 110, 0.52);
+        outline-offset: 4px;
+      }
+
+      .card-top {
+        display: flex;
+        gap: 10px;
+        align-items: flex-start;
+      }
+
+      .card-grip {
+        width: 30px;
+        height: 30px;
+        border-radius: 10px;
+        border: 1px dashed var(--wt-border);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--boards-ink-soft);
+        cursor: grab;
+        flex: 0 0 auto;
+      }
+
+      .card-copy {
+        min-width: 0;
+        flex: 1;
+      }
+
+      .card-copy h4 {
+        margin: 0 0 8px;
+        font-size: 1rem;
+      }
+
+      .card-markdown {
+        color: var(--boards-ink-soft);
+        font-size: 0.92rem;
+        overflow: hidden;
+      }
+
+      .card-markdown > :first-child {
+        margin-top: 0;
+      }
+
+      .card-markdown > :last-child {
+        margin-bottom: 0;
+      }
+
+      .card-markdown pre {
+        overflow: auto;
+        background: rgba(127, 127, 127, 0.1);
+        border-radius: 12px;
+        padding: 10px;
+      }
+
+      .card-markdown code {
+        font-family: var(--wt-font-mono);
+      }
+
+      .card-images {
+        margin-top: 12px;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 8px;
+      }
+
+      .card-images img {
+        width: 100%;
+        aspect-ratio: 4 / 3;
+        object-fit: cover;
+        border-radius: 12px;
+        border: 1px solid var(--wt-border);
+        display: block;
+      }
+
+      .card-hint {
+        margin-top: 12px;
+        font-size: 0.78rem;
+        color: var(--boards-ink-soft);
+      }
+
+      .status-bar {
+        min-height: 24px;
+        font-size: 0.92rem;
+        color: var(--boards-ink-soft);
+      }
+
+      .status-bar.success {
+        color: var(--wt-success);
+      }
+
+      .status-bar.error {
+        color: var(--wt-danger);
+      }
+
+      .status-bar.warning {
+        color: var(--wt-warning);
+      }
+
+      .modal[hidden] {
+        display: none;
+      }
+
+      .modal {
+        position: fixed;
+        inset: 0;
+        z-index: 80;
+        background: rgba(2, 6, 23, 0.6);
+        backdrop-filter: blur(8px);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 20px;
+      }
+
+      .modal-panel {
+        width: min(1080px, 100%);
+        max-height: calc(100vh - 40px);
+        overflow: auto;
+        border-radius: 30px;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        background:
+          radial-gradient(circle at top right, rgba(217, 119, 6, 0.16), transparent 24%),
+          radial-gradient(circle at bottom left, rgba(15, 118, 110, 0.14), transparent 28%),
+          var(--wt-panel-solid);
+        box-shadow: 0 30px 80px rgba(2, 6, 23, 0.38);
+        padding: 24px;
+      }
+
+      .modal-head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 16px;
+      }
+
+      .modal-head h3 {
+        margin: 0;
+        font-size: 1.6rem;
+      }
+
+      .modal-grid {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        gap: 18px;
+        margin-top: 18px;
+      }
+
+      .modal-section {
+        border: 1px solid var(--wt-border);
+        border-radius: 22px;
+        padding: 18px;
+        background: rgba(255, 255, 255, 0.04);
+      }
+
+      .modal-section h4 {
+        margin: 0 0 12px;
+        font-size: 1rem;
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        margin-bottom: 14px;
+      }
+
+      .field label {
+        font-size: 0.86rem;
+        color: var(--boards-ink-soft);
+      }
+
+      .field input,
+      .field textarea {
+        width: 100%;
+        border: 1px solid var(--wt-border);
+        background: rgba(255, 255, 255, 0.06);
+        color: inherit;
+        border-radius: 14px;
+        padding: 12px 13px;
+      }
+
+      .field textarea {
+        min-height: 330px;
+        resize: vertical;
+        font-family: var(--wt-font-mono);
+      }
+
+      .modal-preview {
+        min-height: 330px;
+        max-height: 520px;
+        overflow: auto;
+        border: 1px solid var(--wt-border);
+        border-radius: 18px;
+        padding: 16px;
+        background: rgba(255, 255, 255, 0.05);
+      }
+
+      .modal-preview > :first-child {
+        margin-top: 0;
+      }
+
+      .modal-preview pre {
+        overflow: auto;
+        background: rgba(127, 127, 127, 0.1);
+        border-radius: 12px;
+        padding: 10px;
+      }
+
+      .upload-zone {
+        margin-top: 14px;
+        border: 1px dashed rgba(15, 118, 110, 0.4);
+        border-radius: 18px;
+        padding: 18px;
+        text-align: center;
+        color: var(--boards-ink-soft);
+        background: rgba(15, 118, 110, 0.05);
+      }
+
+      .upload-zone.active {
+        border-color: rgba(15, 118, 110, 0.8);
+        background: rgba(15, 118, 110, 0.12);
+      }
+
+      .image-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .image-card {
+        border: 1px solid var(--wt-border);
+        border-radius: 18px;
+        overflow: hidden;
+        background: rgba(255, 255, 255, 0.04);
+      }
+
+      .image-card img {
+        width: 100%;
+        aspect-ratio: 4 / 3;
+        display: block;
+        object-fit: cover;
+      }
+
+      .image-meta {
+        padding: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+      }
+
+      .muted {
+        color: var(--boards-ink-soft);
+      }
+
+      @media (max-width: 1100px) {
+        .boards-page {
+          grid-template-columns: 1fr;
+        }
+
+        .sidebar {
+          min-height: 0;
+        }
+      }
+
+      @media (max-width: 860px) {
+        .modal-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .board-canvas {
+          padding-bottom: 24px;
+        }
+
+        .list-column {
+          width: min(88vw, 320px);
+          min-width: min(88vw, 320px);
+        }
+
+        .image-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      @media (max-width: 560px) {
+        .workspace,
+        .sidebar {
+          padding: 16px;
+        }
+
+        .workspace-head {
+          flex-direction: column;
+        }
+
+        .sidebar-actions,
+        .workspace-actions {
+          width: 100%;
+        }
+
+        .sidebar-actions .wt-btn,
+        .workspace-actions .wt-btn {
+          flex: 1;
+          justify-content: center;
+        }
+      }
+    </style>
+  </head>
+  <body class="wt" data-wt-tool="boards" data-wt-title="Boards">
+    <div class="wt-header" role="banner"></div>
+    <template id="wtHeaderExtra">
+      <span id="modePill" class="pill">Checking…</span>
+      <div id="authArea"></div>
+    </template>
+
+    <main class="wt-page boards-page">
+      <aside class="panel sidebar">
+        <div class="sidebar-head">
+          <div class="eyebrow">List Manager</div>
+          <h1>Boards</h1>
+          <p class="sidebar-copy">Private Trello-style boards with Markdown cards and image drops saved to D1.</p>
+          <div class="sidebar-actions">
+            <button id="createBoardBtn" class="wt-btn wt-btn-primary" type="button">New board</button>
+            <button id="refreshBoardsBtn" class="wt-btn wt-btn-ghost" type="button">Refresh</button>
+          </div>
+        </div>
+        <div id="boardList" class="board-list"></div>
+      </aside>
+
+      <section class="panel workspace">
+        <div id="authPanel" class="auth-panel" hidden>
+          <h3>Sign in to manage boards</h3>
+          <p>Your boards, lists, cards, Markdown, and dropped images are stored in your account and synced through D1.</p>
+          <a id="loginButton" class="wt-btn wt-btn-primary" href="/auth/google/login?returnTo=/boards">Sign in with Google</a>
+        </div>
+
+        <div id="emptyPanel" class="empty-panel" hidden>
+          <h3>No boards yet</h3>
+          <p>Create a board, add lists, then drag cards between columns. Drop an image on any card to attach it instantly.</p>
+          <button id="emptyCreateBoardBtn" class="wt-btn wt-btn-primary" type="button">Create your first board</button>
+        </div>
+
+        <div id="boardPane" hidden>
+          <div class="workspace-head">
+            <div class="workspace-title">
+              <div class="eyebrow">Workspace</div>
+              <h2 id="boardTitle">Boards</h2>
+              <p id="boardDescription" class="muted"></p>
+            </div>
+            <div class="workspace-actions">
+              <button id="renameBoardBtn" class="wt-btn wt-btn-ghost" type="button">Edit board</button>
+              <button id="deleteBoardBtn" class="wt-btn wt-btn-danger" type="button">Delete board</button>
+              <button id="addListBtn" class="wt-btn wt-btn-primary" type="button">Add list</button>
+            </div>
+          </div>
+          <div id="boardCanvas" class="board-canvas"></div>
+        </div>
+
+        <div id="statusBar" class="status-bar" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <div id="cardModal" class="modal" hidden>
+      <div class="modal-panel">
+        <div class="modal-head">
+          <div>
+            <div class="eyebrow">Card editor</div>
+            <h3 id="cardModalTitle">Edit card</h3>
+          </div>
+          <div class="workspace-actions">
+            <button id="closeCardModalBtn" class="wt-btn wt-btn-ghost" type="button">Close</button>
+            <button id="deleteCardBtn" class="wt-btn wt-btn-danger" type="button">Delete card</button>
+            <button id="saveCardBtn" class="wt-btn wt-btn-primary" type="button">Save</button>
+          </div>
+        </div>
+
+        <div class="modal-grid">
+          <section class="modal-section">
+            <div class="field">
+              <label for="cardTitleInput">Title</label>
+              <input id="cardTitleInput" type="text" maxlength="160" />
+            </div>
+            <div class="field">
+              <label for="cardMarkdownInput">Markdown</label>
+              <textarea id="cardMarkdownInput" spellcheck="false"></textarea>
+            </div>
+          </section>
+
+          <section class="modal-section">
+            <h4>Preview</h4>
+            <div id="cardPreview" class="modal-preview"></div>
+          </section>
+        </div>
+
+        <section class="modal-section" style="margin-top: 18px;">
+          <h4>Images</h4>
+          <p class="muted" style="margin-top: 0;">Drop PNG, JPEG, WEBP, GIF, or AVIF files here or directly onto a card. Maximum 3 images per card, 1 MB each.</p>
+          <div id="modalUploadZone" class="upload-zone">Drop an image here to attach it to this card.</div>
+          <div id="modalImageGrid" class="image-grid" style="margin-top: 14px;"></div>
+        </section>
+      </div>
+    </div>
+
+    <script>
+      (function() {
+        const ACTIVE_BOARD_KEY = 'wt_boards_active_v1';
+        const MAX_IMAGE_BYTES = 1024 * 1024;
+        const ALLOWED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/avif']);
+
+        const state = {
+          auth: { loggedIn: false, user: null },
+          boards: [],
+          board: null,
+          activeBoardId: '',
+          editingCardId: '',
+          drag: null,
+        };
+
+        const boardListEl = document.getElementById('boardList');
+        const authAreaEl = document.getElementById('authArea');
+        const authPanelEl = document.getElementById('authPanel');
+        const emptyPanelEl = document.getElementById('emptyPanel');
+        const boardPaneEl = document.getElementById('boardPane');
+        const boardCanvasEl = document.getElementById('boardCanvas');
+        const boardTitleEl = document.getElementById('boardTitle');
+        const boardDescriptionEl = document.getElementById('boardDescription');
+        const statusBarEl = document.getElementById('statusBar');
+        const modePillEl = document.getElementById('modePill');
+        const cardModalEl = document.getElementById('cardModal');
+        const cardModalTitleEl = document.getElementById('cardModalTitle');
+        const cardTitleInputEl = document.getElementById('cardTitleInput');
+        const cardMarkdownInputEl = document.getElementById('cardMarkdownInput');
+        const cardPreviewEl = document.getElementById('cardPreview');
+        const modalUploadZoneEl = document.getElementById('modalUploadZone');
+        const modalImageGridEl = document.getElementById('modalImageGrid');
+
+        if (window.marked && typeof window.marked.setOptions === 'function') {
+          window.marked.setOptions({ gfm: true, breaks: true });
+        }
+
+        function el(tag, props = {}, children = []) {
+          const node = document.createElement(tag);
+          Object.entries(props).forEach(([key, value]) => {
+            if (value === undefined || value === null) return;
+            if (key === 'class') node.className = value;
+            else if (key === 'text') node.textContent = value;
+            else if (key === 'html') node.innerHTML = value;
+            else if (key.startsWith('on') && typeof value === 'function') node[key.toLowerCase()] = value;
+            else node.setAttribute(key, value);
+          });
+          for (const child of children) {
+            if (child === null || child === undefined) continue;
+            if (typeof child === 'string') node.appendChild(document.createTextNode(child));
+            else node.appendChild(child);
+          }
+          return node;
+        }
+
+        function setStatus(message, kind = 'info') {
+          statusBarEl.textContent = message || '';
+          statusBarEl.className = 'status-bar' + (kind && kind !== 'info' ? ' ' + kind : '');
+        }
+
+        async function api(path, options = {}) {
+          const res = await fetch(path, Object.assign({ credentials: 'include' }, options));
+          if (!res.ok) {
+            throw new Error((await res.text()) || 'Request failed');
+          }
+          return res.json();
+        }
+
+        function sanitizeMarkdown(markdown) {
+          const raw = window.marked ? window.marked.parse(markdown || '') : '';
+          return window.DOMPurify ? window.DOMPurify.sanitize(raw) : raw;
+        }
+
+        function renderMarkdown(markdown) {
+          return sanitizeMarkdown(markdown || '');
+        }
+
+        function formatBoardMeta(board) {
+          const pieces = [];
+          pieces.push(`${board.list_count || 0} list${board.list_count === 1 ? '' : 's'}`);
+          pieces.push(`${board.card_count || 0} card${board.card_count === 1 ? '' : 's'}`);
+          return pieces.join(' • ');
+        }
+
+        function persistActiveBoard(id) {
+          state.activeBoardId = id || '';
+          if (id) localStorage.setItem(ACTIVE_BOARD_KEY, id);
+          else localStorage.removeItem(ACTIVE_BOARD_KEY);
+          const next = new URL(location.href);
+          if (id) next.searchParams.set('board', id);
+          else next.searchParams.delete('board');
+          history.replaceState({}, '', next.pathname + next.search + next.hash);
+        }
+
+        function preferredBoardId() {
+          const fromUrl = new URL(location.href).searchParams.get('board');
+          if (fromUrl && state.boards.some((board) => board.id === fromUrl)) return fromUrl;
+          const fromStorage = localStorage.getItem(ACTIVE_BOARD_KEY);
+          if (fromStorage && state.boards.some((board) => board.id === fromStorage)) return fromStorage;
+          return state.boards[0]?.id || '';
+        }
+
+        function renderAuthArea() {
+          authAreaEl.innerHTML = '';
+          if (!state.auth.loggedIn) {
+            const next = encodeURIComponent(location.pathname + location.search);
+            authAreaEl.appendChild(el('a', {
+              class: 'wt-btn wt-btn-primary',
+              href: '/auth/google/login?returnTo=' + next,
+              text: 'Sign in',
+            }));
+            modePillEl.textContent = 'Guest mode';
+            modePillEl.classList.remove('accent');
+            return;
+          }
+
+          modePillEl.textContent = 'Account storage';
+          modePillEl.classList.add('accent');
+          authAreaEl.appendChild(el('span', { text: state.auth.user?.email || 'Signed in' }));
+          authAreaEl.appendChild(el('button', {
+            class: 'wt-btn wt-btn-ghost',
+            type: 'button',
+            text: 'Logout',
+            onclick: async () => {
+              try {
+                await api('/api/auth/logout', { method: 'POST' });
+              } catch {}
+              state.auth = { loggedIn: false, user: null };
+              state.boards = [];
+              state.board = null;
+              persistActiveBoard('');
+              closeCardModal();
+              renderAll();
+              setStatus('Signed out.', 'success');
+            },
+          }));
+        }
+
+        function renderSidebar() {
+          boardListEl.innerHTML = '';
+
+          if (!state.auth.loggedIn) {
+            boardListEl.appendChild(el('div', { class: 'card-empty', text: 'Sign in to load your boards.' }));
+            return;
+          }
+
+          if (!state.boards.length) {
+            boardListEl.appendChild(el('div', { class: 'card-empty', text: 'No boards yet. Create one to begin.' }));
+            return;
+          }
+
+          state.boards.forEach((board) => {
+            boardListEl.appendChild(el('button', {
+              class: 'board-item' + (board.id === state.activeBoardId ? ' active' : ''),
+              type: 'button',
+              onclick: () => setActiveBoard(board.id),
+            }, [
+              el('h3', { text: board.title }),
+              el('p', { text: board.description || 'Markdown cards, drag-and-drop lanes, and private sync.' }),
+              el('div', { class: 'board-meta' }, [
+                el('span', { class: 'meta-pill', text: formatBoardMeta(board) }),
+              ]),
+            ]));
+          });
+        }
+
+        function renderWorkspace() {
+          authPanelEl.hidden = state.auth.loggedIn;
+          emptyPanelEl.hidden = !state.auth.loggedIn || !!state.boards.length;
+          boardPaneEl.hidden = !state.auth.loggedIn || !state.board;
+
+          if (!state.auth.loggedIn) return;
+          if (!state.board) return;
+
+          boardTitleEl.textContent = state.board.board.title;
+          boardDescriptionEl.textContent = state.board.board.description || 'Organize work in draggable lists and cards.';
+          boardCanvasEl.innerHTML = '';
+
+          state.board.lists.forEach((list) => {
+            const listEl = el('section', {
+              class: 'list-column',
+              draggable: 'true',
+              'data-list-id': list.id,
+              ondragstart: (event) => {
+                state.drag = { type: 'list', id: list.id };
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('text/plain', list.id);
+              },
+              ondragend: () => { state.drag = null; clearDragClasses(); },
+              ondragover: (event) => handleListDragOver(event, list.id),
+              ondragleave: () => clearListDragClass(listEl),
+              ondrop: (event) => handleListDrop(event, list.id),
+            });
+
+            listEl.appendChild(el('div', { class: 'list-head' }, [
+              el('button', { class: 'drag-handle', type: 'button', text: '⋮⋮', title: 'Drag list' }),
+              el('div', { class: 'list-body' }, [
+                el('div', { class: 'list-title-row' }, [
+                  el('h3', { text: list.title }),
+                  el('span', { class: 'meta-pill', text: `${list.cards.length}` }),
+                ]),
+                el('div', { class: 'list-actions' }, [
+                  el('button', {
+                    class: 'wt-btn wt-btn-ghost',
+                    type: 'button',
+                    text: 'Rename',
+                    onclick: (event) => {
+                      event.stopPropagation();
+                      renameList(list);
+                    },
+                  }),
+                  el('button', {
+                    class: 'wt-btn wt-btn-danger',
+                    type: 'button',
+                    text: 'Delete',
+                    onclick: (event) => {
+                      event.stopPropagation();
+                      deleteList(list);
+                    },
+                  }),
+                ]),
+              ]),
+            ]));
+
+            const stackEl = el('div', {
+              class: 'card-stack',
+              'data-list-id': list.id,
+              ondragover: (event) => handleCardStackDragOver(event, list.id),
+              ondragleave: () => clearStackDragClass(stackEl),
+              ondrop: (event) => handleCardStackDrop(event, list.id),
+            });
+
+            if (!list.cards.length) {
+              stackEl.appendChild(el('div', {
+                class: 'card-empty',
+                text: 'Drop a card here or add one below.',
+              }));
+            }
+
+            list.cards.forEach((card) => {
+              const cardEl = el('article', {
+                class: 'card-item',
+                draggable: 'true',
+                'data-card-id': card.id,
+                onclick: () => openCard(card.id),
+                ondragstart: (event) => {
+                  state.drag = { type: 'card', id: card.id, fromListId: list.id };
+                  event.dataTransfer.effectAllowed = 'move';
+                  event.dataTransfer.setData('text/plain', card.id);
+                },
+                ondragend: () => { state.drag = null; clearDragClasses(); },
+                ondragover: (event) => handleCardDragOver(event, list.id, card.id, cardEl),
+                ondragleave: () => clearCardDragClass(cardEl),
+                ondrop: (event) => handleCardDrop(event, list.id, card.id, cardEl),
+              });
+
+              cardEl.appendChild(el('div', { class: 'card-top' }, [
+                el('div', { class: 'card-grip', text: '⋮', title: 'Drag card' }),
+                el('div', { class: 'card-copy' }, [
+                  el('h4', { text: card.title }),
+                  el('div', { class: 'card-markdown', html: renderMarkdown(card.markdown || '') }),
+                ]),
+              ]));
+
+              if (card.images && card.images.length) {
+                const imagesEl = el('div', { class: 'card-images' });
+                card.images.slice(0, 4).forEach((image) => {
+                  imagesEl.appendChild(el('img', {
+                    src: image.data_url,
+                    alt: image.alt_text || card.title,
+                    loading: 'lazy',
+                  }));
+                });
+                cardEl.appendChild(imagesEl);
+              }
+
+              cardEl.appendChild(el('div', {
+                class: 'card-hint',
+                text: 'Click to edit. Drop an image onto this card to attach it.',
+              }));
+
+              stackEl.appendChild(cardEl);
+            });
+
+            listEl.appendChild(stackEl);
+            listEl.appendChild(el('button', {
+              class: 'wt-btn wt-btn-primary',
+              type: 'button',
+              text: '+ Add card',
+              onclick: () => createCard(list.id),
+              style: 'margin-top: 14px;',
+            }));
+
+            boardCanvasEl.appendChild(listEl);
+          });
+        }
+
+        function renderAll() {
+          document.getElementById('createBoardBtn').disabled = !state.auth.loggedIn;
+          document.getElementById('refreshBoardsBtn').disabled = !state.auth.loggedIn;
+          renderAuthArea();
+          renderSidebar();
+          renderWorkspace();
+        }
+
+        function clearDragClasses() {
+          document.querySelectorAll('.drag-target-before').forEach((node) => node.classList.remove('drag-target-before'));
+          document.querySelectorAll('.drag-target-after').forEach((node) => node.classList.remove('drag-target-after'));
+          document.querySelectorAll('.drag-target').forEach((node) => node.classList.remove('drag-target'));
+          document.querySelectorAll('.file-target').forEach((node) => node.classList.remove('file-target'));
+          document.querySelectorAll('.upload-zone.active').forEach((node) => node.classList.remove('active'));
+        }
+
+        function clearListDragClass(listEl) {
+          listEl.classList.remove('drag-target-before', 'drag-target-after');
+        }
+
+        function clearCardDragClass(cardEl) {
+          cardEl.classList.remove('drag-target-before', 'drag-target-after', 'file-target');
+        }
+
+        function clearStackDragClass(stackEl) {
+          stackEl.classList.remove('drag-target');
+        }
+
+        function hasFileDrop(event) {
+          return !!(event.dataTransfer && event.dataTransfer.files && event.dataTransfer.files.length);
+        }
+
+        function moveIdRelative(ids, movedId, targetId, placeAfter) {
+          const next = ids.filter((id) => id !== movedId);
+          if (!targetId) {
+            next.push(movedId);
+            return next;
+          }
+          const targetIndex = next.indexOf(targetId);
+          if (targetIndex === -1) {
+            next.push(movedId);
+            return next;
+          }
+          next.splice(targetIndex + (placeAfter ? 1 : 0), 0, movedId);
+          return next;
+        }
+
+        function listById(listId) {
+          return state.board?.lists.find((list) => list.id === listId) || null;
+        }
+
+        function cardById(cardId) {
+          for (const list of state.board?.lists || []) {
+            const card = list.cards.find((entry) => entry.id === cardId);
+            if (card) return { list, card };
+          }
+          return null;
+        }
+
+        function isSameOrder(left, right) {
+          if (left.length !== right.length) return false;
+          return left.every((value, index) => value === right[index]);
+        }
+
+        async function refreshAuth() {
+          try {
+            const me = await api('/api/auth/me');
+            state.auth = { loggedIn: !!me.loggedIn, user: me.user || null };
+          } catch {
+            state.auth = { loggedIn: false, user: null };
+          }
+
+          if (!state.auth.loggedIn) {
+            state.boards = [];
+            state.board = null;
+            persistActiveBoard('');
+            closeCardModal();
+            renderAll();
+            return;
+          }
+
+          await loadBoards();
+        }
+
+        async function loadBoards() {
+          if (!state.auth.loggedIn) return;
+          state.boards = await api('/api/boards/list');
+          const nextActiveId = state.boards.some((board) => board.id === state.activeBoardId)
+            ? state.activeBoardId
+            : preferredBoardId();
+          persistActiveBoard(nextActiveId);
+          renderSidebar();
+          if (state.activeBoardId) await loadBoard(state.activeBoardId);
+          else {
+            state.board = null;
+            closeCardModal();
+            renderWorkspace();
+          }
+        }
+
+        async function loadBoard(boardId, options = {}) {
+          if (!boardId) {
+            state.board = null;
+            renderWorkspace();
+            return;
+          }
+          state.board = await api('/api/boards/get?id=' + encodeURIComponent(boardId));
+          persistActiveBoard(boardId);
+          renderWorkspace();
+          if (options.reopenCardId) openCard(options.reopenCardId);
+        }
+
+        async function setActiveBoard(boardId) {
+          if (!boardId) return;
+          try {
+            await loadBoard(boardId);
+            setStatus('Board loaded.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        async function createBoard() {
+          const title = window.prompt('Board title', 'New board');
+          if (title === null) return;
+          const description = window.prompt('Board description (optional)', '') ?? '';
+          try {
+            const created = await api('/api/boards/create', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ title, description }),
+            });
+            await loadBoards();
+            if (created.id) await setActiveBoard(created.id);
+            setStatus('Board created.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        async function renameBoard() {
+          if (!state.board) return;
+          const current = state.board.board;
+          const title = window.prompt('Board title', current.title);
+          if (title === null) return;
+          const description = window.prompt('Board description (optional)', current.description || '');
+          if (description === null) return;
+          try {
+            await api('/api/boards/update', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ id: current.id, title, description }),
+            });
+            await loadBoards();
+            await loadBoard(current.id);
+            setStatus('Board updated.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        async function deleteBoard() {
+          if (!state.board) return;
+          const current = state.board.board;
+          if (!window.confirm(`Delete "${current.title}" and all of its lists, cards, and images?`)) return;
+          try {
+            await api('/api/boards/delete', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ id: current.id }),
+            });
+            closeCardModal();
+            await loadBoards();
+            setStatus('Board deleted.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        async function createList() {
+          if (!state.board) return;
+          const title = window.prompt('List title', 'New list');
+          if (title === null) return;
+          try {
+            await api('/api/boards/lists/create', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ board_id: state.board.board.id, title }),
+            });
+            await loadBoards();
+            await loadBoard(state.board.board.id);
+            setStatus('List created.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        async function renameList(list) {
+          const title = window.prompt('List title', list.title);
+          if (title === null) return;
+          try {
+            await api('/api/boards/lists/update', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ id: list.id, title }),
+            });
+            await loadBoards();
+            await loadBoard(state.board.board.id);
+            setStatus('List updated.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        async function deleteList(list) {
+          if (!window.confirm(`Delete "${list.title}" and all of its cards?`)) return;
+          try {
+            await api('/api/boards/lists/delete', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ id: list.id }),
+            });
+            closeCardModal();
+            await loadBoards();
+            await loadBoard(state.board.board.id);
+            setStatus('List deleted.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        async function createCard(listId) {
+          const title = window.prompt('Card title', 'Untitled card');
+          if (title === null) return;
+          try {
+            const created = await api('/api/boards/cards/create', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ list_id: listId, title, markdown: '' }),
+            });
+            await loadBoards();
+            await loadBoard(state.board.board.id, { reopenCardId: created.id });
+            setStatus('Card created.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        function openCard(cardId) {
+          const found = cardById(cardId);
+          if (!found) return;
+          state.editingCardId = cardId;
+          cardModalTitleEl.textContent = found.card.title;
+          cardTitleInputEl.value = found.card.title || '';
+          cardMarkdownInputEl.value = found.card.markdown || '';
+          syncCardPreview();
+          renderModalImages(found.card.images || []);
+          cardModalEl.hidden = false;
+        }
+
+        function closeCardModal() {
+          state.editingCardId = '';
+          cardModalEl.hidden = true;
+        }
+
+        function syncCardPreview() {
+          cardPreviewEl.innerHTML = renderMarkdown(cardMarkdownInputEl.value || '');
+        }
+
+        function renderModalImages(images) {
+          modalImageGridEl.innerHTML = '';
+          if (!images.length) {
+            modalImageGridEl.appendChild(el('div', {
+              class: 'card-empty',
+              text: 'No images attached yet.',
+            }));
+            return;
+          }
+
+          images.forEach((image) => {
+            modalImageGridEl.appendChild(el('div', { class: 'image-card' }, [
+              el('img', {
+                src: image.data_url,
+                alt: image.alt_text || 'Card image',
+                loading: 'lazy',
+              }),
+              el('div', { class: 'image-meta' }, [
+                el('span', { class: 'muted', text: image.mime_type.replace('image/', '').toUpperCase() }),
+                el('button', {
+                  class: 'wt-btn wt-btn-danger',
+                  type: 'button',
+                  text: 'Remove',
+                  onclick: async () => {
+                    try {
+                      await api('/api/boards/cards/images/delete', {
+                        method: 'POST',
+                        headers: { 'content-type': 'application/json' },
+                        body: JSON.stringify({ id: image.id }),
+                      });
+                      await loadBoards();
+                      await loadBoard(state.board.board.id, { reopenCardId: state.editingCardId });
+                      setStatus('Image removed.', 'success');
+                    } catch (error) {
+                      setStatus(error.message, 'error');
+                    }
+                  },
+                }),
+              ]),
+            ]));
+          });
+        }
+
+        async function saveCard() {
+          if (!state.editingCardId) return;
+          try {
+            await api('/api/boards/cards/update', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                id: state.editingCardId,
+                title: cardTitleInputEl.value,
+                markdown: cardMarkdownInputEl.value,
+              }),
+            });
+            await loadBoards();
+            await loadBoard(state.board.board.id, { reopenCardId: state.editingCardId });
+            setStatus('Card saved.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        async function deleteCard() {
+          if (!state.editingCardId) return;
+          const found = cardById(state.editingCardId);
+          if (!found) return;
+          if (!window.confirm(`Delete "${found.card.title}"?`)) return;
+          try {
+            await api('/api/boards/cards/delete', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ id: state.editingCardId }),
+            });
+            closeCardModal();
+            await loadBoards();
+            await loadBoard(state.board.board.id);
+            setStatus('Card deleted.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        async function uploadImageToCard(cardId, file) {
+          if (!file) return;
+          if (!ALLOWED_IMAGE_TYPES.has(file.type)) {
+            throw new Error('Only PNG, JPEG, WEBP, GIF, and AVIF images are supported.');
+          }
+          if (file.size > MAX_IMAGE_BYTES) {
+            throw new Error('Images must be 1 MB or smaller.');
+          }
+          const dataUrl = await new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result);
+            reader.onerror = () => reject(new Error('Could not read the dropped image.'));
+            reader.readAsDataURL(file);
+          });
+          await api('/api/boards/cards/images/add', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ card_id: cardId, data_url: dataUrl, alt_text: file.name || '' }),
+          });
+        }
+
+        async function handleDroppedFiles(cardId, files) {
+          if (!files || !files.length) return;
+          try {
+            await uploadImageToCard(cardId, files[0]);
+            await loadBoards();
+            await loadBoard(state.board.board.id, state.editingCardId ? { reopenCardId: state.editingCardId } : {});
+            setStatus('Image attached to card.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        function handleListDragOver(event, targetListId) {
+          if (!state.drag || state.drag.type !== 'list') return;
+          event.preventDefault();
+          const element = event.currentTarget;
+          const rect = element.getBoundingClientRect();
+          const placeAfter = event.clientX > rect.left + rect.width / 2;
+          clearListDragClass(element);
+          element.classList.add(placeAfter ? 'drag-target-after' : 'drag-target-before');
+        }
+
+        async function handleListDrop(event, targetListId) {
+          if (!state.drag || state.drag.type !== 'list') return;
+          event.preventDefault();
+          const element = event.currentTarget;
+          const rect = element.getBoundingClientRect();
+          const placeAfter = event.clientX > rect.left + rect.width / 2;
+          clearDragClasses();
+          const currentIds = state.board.lists.map((list) => list.id);
+          const nextIds = moveIdRelative(currentIds, state.drag.id, targetListId, placeAfter);
+          state.drag = null;
+          if (isSameOrder(currentIds, nextIds)) return;
+          try {
+            await api('/api/boards/lists/reorder', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({ board_id: state.board.board.id, list_ids: nextIds }),
+            });
+            await loadBoards();
+            await loadBoard(state.board.board.id);
+            setStatus('Lists reordered.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        function handleCardDragOver(event, listId, cardId, cardEl) {
+          if (hasFileDrop(event)) {
+            event.preventDefault();
+            clearCardDragClass(cardEl);
+            cardEl.classList.add('file-target');
+            return;
+          }
+          if (!state.drag || state.drag.type !== 'card') return;
+          event.preventDefault();
+          const rect = cardEl.getBoundingClientRect();
+          const placeAfter = event.clientY > rect.top + rect.height / 2;
+          clearCardDragClass(cardEl);
+          cardEl.classList.add(placeAfter ? 'drag-target-after' : 'drag-target-before');
+        }
+
+        async function handleCardDrop(event, listId, cardId, cardEl) {
+          event.preventDefault();
+          clearCardDragClass(cardEl);
+          if (hasFileDrop(event)) {
+            await handleDroppedFiles(cardId, event.dataTransfer.files);
+            return;
+          }
+          if (!state.drag || state.drag.type !== 'card') return;
+
+          const rect = cardEl.getBoundingClientRect();
+          const placeAfter = event.clientY > rect.top + rect.height / 2;
+          const { id: draggedId, fromListId } = state.drag;
+          state.drag = null;
+          clearDragClasses();
+
+          const sourceList = listById(fromListId);
+          const destinationList = listById(listId);
+          if (!sourceList || !destinationList) return;
+
+          if (fromListId === listId) {
+            const currentIds = sourceList.cards.map((card) => card.id);
+            const nextIds = moveIdRelative(currentIds, draggedId, cardId, placeAfter);
+            if (isSameOrder(currentIds, nextIds)) return;
+            try {
+              await api('/api/boards/cards/move', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                  card_id: draggedId,
+                  to_list_id: listId,
+                  destination_card_ids: nextIds,
+                }),
+              });
+              await loadBoards();
+              await loadBoard(state.board.board.id);
+              setStatus('Cards reordered.', 'success');
+            } catch (error) {
+              setStatus(error.message, 'error');
+            }
+            return;
+          }
+
+          const sourceIds = sourceList.cards.map((card) => card.id).filter((id) => id !== draggedId);
+          const destinationIds = moveIdRelative(destinationList.cards.map((card) => card.id), draggedId, cardId, placeAfter);
+          try {
+            await api('/api/boards/cards/move', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                card_id: draggedId,
+                to_list_id: listId,
+                source_card_ids: sourceIds,
+                destination_card_ids: destinationIds,
+              }),
+            });
+            await loadBoards();
+            await loadBoard(state.board.board.id);
+            setStatus('Card moved.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        function handleCardStackDragOver(event, listId) {
+          if (!state.drag || state.drag.type !== 'card') return;
+          event.preventDefault();
+          event.currentTarget.classList.add('drag-target');
+        }
+
+        async function handleCardStackDrop(event, listId) {
+          event.preventDefault();
+          clearStackDragClass(event.currentTarget);
+          if (!state.drag || state.drag.type !== 'card') return;
+          const { id: draggedId, fromListId } = state.drag;
+          state.drag = null;
+          clearDragClasses();
+
+          const sourceList = listById(fromListId);
+          const destinationList = listById(listId);
+          if (!sourceList || !destinationList) return;
+
+          const destinationIds = destinationList.cards.map((card) => card.id).filter((id) => id !== draggedId);
+          destinationIds.push(draggedId);
+
+          if (fromListId === listId) {
+            const currentIds = sourceList.cards.map((card) => card.id);
+            if (isSameOrder(currentIds, destinationIds)) return;
+            try {
+              await api('/api/boards/cards/move', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                  card_id: draggedId,
+                  to_list_id: listId,
+                  destination_card_ids: destinationIds,
+                }),
+              });
+              await loadBoards();
+              await loadBoard(state.board.board.id);
+              setStatus('Cards reordered.', 'success');
+            } catch (error) {
+              setStatus(error.message, 'error');
+            }
+            return;
+          }
+
+          const sourceIds = sourceList.cards.map((card) => card.id).filter((id) => id !== draggedId);
+          try {
+            await api('/api/boards/cards/move', {
+              method: 'POST',
+              headers: { 'content-type': 'application/json' },
+              body: JSON.stringify({
+                card_id: draggedId,
+                to_list_id: listId,
+                source_card_ids: sourceIds,
+                destination_card_ids: destinationIds,
+              }),
+            });
+            await loadBoards();
+            await loadBoard(state.board.board.id);
+            setStatus('Card moved.', 'success');
+          } catch (error) {
+            setStatus(error.message, 'error');
+          }
+        }
+
+        function bindStaticEvents() {
+          document.getElementById('createBoardBtn').addEventListener('click', createBoard);
+          document.getElementById('refreshBoardsBtn').addEventListener('click', async () => {
+            try {
+              await loadBoards();
+              setStatus('Boards refreshed.', 'success');
+            } catch (error) {
+              setStatus(error.message, 'error');
+            }
+          });
+          document.getElementById('emptyCreateBoardBtn').addEventListener('click', createBoard);
+          document.getElementById('renameBoardBtn').addEventListener('click', renameBoard);
+          document.getElementById('deleteBoardBtn').addEventListener('click', deleteBoard);
+          document.getElementById('addListBtn').addEventListener('click', createList);
+          document.getElementById('saveCardBtn').addEventListener('click', saveCard);
+          document.getElementById('deleteCardBtn').addEventListener('click', deleteCard);
+          document.getElementById('closeCardModalBtn').addEventListener('click', closeCardModal);
+          cardModalEl.addEventListener('click', (event) => {
+            if (event.target === cardModalEl) closeCardModal();
+          });
+          cardMarkdownInputEl.addEventListener('input', syncCardPreview);
+          cardTitleInputEl.addEventListener('input', () => {
+            cardModalTitleEl.textContent = cardTitleInputEl.value || 'Edit card';
+          });
+          modalUploadZoneEl.addEventListener('dragover', (event) => {
+            event.preventDefault();
+            modalUploadZoneEl.classList.add('active');
+          });
+          modalUploadZoneEl.addEventListener('dragleave', () => {
+            modalUploadZoneEl.classList.remove('active');
+          });
+          modalUploadZoneEl.addEventListener('drop', async (event) => {
+            event.preventDefault();
+            modalUploadZoneEl.classList.remove('active');
+            if (!state.editingCardId) return;
+            await handleDroppedFiles(state.editingCardId, event.dataTransfer.files);
+          });
+        }
+
+        async function boot() {
+          bindStaticEvents();
+          renderAll();
+          await refreshAuth();
+          setStatus('Boards ready.');
+        }
+
+        boot().catch((error) => {
+          setStatus(error instanceof Error ? error.message : 'Failed to load boards.', 'error');
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -248,6 +248,18 @@
         <p>Share text snippets with public or unlisted links.</p>
       </a>
 
+      <a class="tile" href="/boards" data-keywords="boards kanban trello list manager cards markdown drag drop images d1 oauth">
+        <div class="tile-icon">
+          <svg viewBox="0 0 24 24">
+            <rect x="3" y="4" width="6" height="16" rx="1.5"></rect>
+            <rect x="10.5" y="8" width="6" height="12" rx="1.5"></rect>
+            <rect x="18" y="11" width="3" height="9" rx="1.2"></rect>
+          </svg>
+        </div>
+        <h2>Boards</h2>
+        <p>Create Trello-style boards with draggable lists, Markdown cards, and image drops saved to your account.</p>
+      </a>
+
       <a class="tile" href="/diff" data-keywords="diff compare text git patch changes">
         <div class="tile-icon">
           <svg viewBox="0 0 24 24">

--- a/public/shared/toolkit.js
+++ b/public/shared/toolkit.js
@@ -18,6 +18,7 @@
     { id: 'llm-cost', title: 'LLM Cost', href: '/llm-cost' },
     { id: 'tiff-viewer', title: 'TIFF Viewer', href: '/tiff-viewer' },
     { id: 'todo', title: 'To-Do', href: '/todo' },
+    { id: 'boards', title: 'Boards', href: '/boards' },
     { id: 'goals', title: 'Goals', href: '/goals' },
     { id: 'actuary', title: 'Actuary', href: '/actuary' },
   ];

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -30,6 +30,39 @@ export function isAllowedEmail(email?: string | null): boolean {
   return (email || '').toLowerCase() === 'bruce.hart@gmail.com';
 }
 
+function buildRequestCallbackUrl(url: URL): string {
+  return new URL('/auth/google/callback', url.origin).toString();
+}
+
+function resolveOAuthRedirectUrl(url: URL, env: Bindings): string | null {
+  const requestCallback = buildRequestCallbackUrl(url);
+  const configured = (env.OAUTH_REDIRECT_URL || '').trim();
+  if (!configured) return requestCallback;
+
+  try {
+    const configuredUrl = new URL(configured);
+    if (configuredUrl.origin === url.origin) return configuredUrl.toString();
+    if (configuredUrl.pathname !== '/auth/google/callback') return configuredUrl.toString();
+    return requestCallback;
+  } catch {
+    return requestCallback;
+  }
+}
+
+function normalizeRedirectUri(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    const parsed = new URL(value.trim());
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null;
+    if (parsed.pathname !== '/auth/google/callback') return null;
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
 function normalizeReturnTo(value: string | null): string | null {
   if (!value) return null;
   const trimmed = value.trim();
@@ -73,7 +106,7 @@ export async function handleAuthRoutes(
 
   if (path === '/auth/google/login' && request.method === 'GET') {
     const clientId = env.GOOGLE_CLIENT_ID;
-    const redirect = env.OAUTH_REDIRECT_URL;
+    const redirect = resolveOAuthRedirectUrl(url, env);
     if (!clientId || !redirect) return badRequest('Google OAuth not configured', 500);
     // Support both ?returnTo=... (newer) and ?next=... (older/tools built on the previous convention).
     const returnTo = normalizeReturnTo(url.searchParams.get('returnTo') || url.searchParams.get('next'));
@@ -86,6 +119,13 @@ export async function handleAuthRoutes(
     oauthUrl.searchParams.set('state', state);
     const res = new Response(null, { status: 302, headers: { location: oauthUrl.toString() } });
     setCookie(res, 'oauth_state', state, {
+      path: '/',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Lax',
+      maxAge: 600,
+    });
+    setCookie(res, 'oauth_redirect_uri', redirect, {
       path: '/',
       httpOnly: true,
       secure: true,
@@ -109,11 +149,12 @@ export async function handleAuthRoutes(
   if (path === '/auth/google/callback' && request.method === 'GET') {
     const state = url.searchParams.get('state') || '';
     const code = url.searchParams.get('code') || '';
-    const cookieState = getCookies(request)['oauth_state'];
+    const cookies = getCookies(request);
+    const cookieState = cookies['oauth_state'];
     if (!code || !state || !cookieState || state !== cookieState) return badRequest('Invalid state');
     const clientId = env.GOOGLE_CLIENT_ID || '';
     const clientSecret = (env as any).GOOGLE_CLIENT_SECRET as string | undefined;
-    const redirect = env.OAUTH_REDIRECT_URL || '';
+    const redirect = normalizeRedirectUri(cookies['oauth_redirect_uri']) || resolveOAuthRedirectUrl(url, env) || '';
     if (!clientId || !clientSecret || !redirect) return badRequest('OAuth not configured', 500);
     const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',
@@ -150,6 +191,7 @@ export async function handleAuthRoutes(
     const returnTo = normalizeReturnTo(getCookies(request)['oauth_return_to']);
     const res = new Response(null, { status: 302, headers: { location: returnTo || '/pastebin' } });
     setCookie(res, 'oauth_state', '', { path: '/', maxAge: 0 });
+    setCookie(res, 'oauth_redirect_uri', '', { path: '/', maxAge: 0 });
     setCookie(res, 'oauth_return_to', '', { path: '/', maxAge: 0 });
     setCookie(res, env.SESSION_COOKIE_NAME || 'wt_session', token, {
       path: '/',

--- a/src/boards.ts
+++ b/src/boards.ts
@@ -1,0 +1,730 @@
+import { requireUser } from './auth';
+import { badRequest, json, readJson } from './utils/http';
+import { urlSafeRandom } from './utils/random';
+import type { Bindings, HandlerResult } from './types';
+
+type BoardRow = {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string | null;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+};
+
+type BoardListRow = {
+  id: string;
+  board_id: string;
+  title: string;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+};
+
+type BoardCardRow = {
+  id: string;
+  board_id: string;
+  list_id: string;
+  title: string;
+  markdown: string;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+};
+
+type CardImageRow = {
+  id: string;
+  card_id: string;
+  mime_type: string;
+  data_url: string;
+  alt_text: string | null;
+  sort_order: number;
+  created_at: string;
+};
+
+const MAX_BOARD_TITLE_LENGTH = 120;
+const MAX_BOARD_DESCRIPTION_LENGTH = 500;
+const MAX_LIST_TITLE_LENGTH = 120;
+const MAX_CARD_TITLE_LENGTH = 160;
+const MAX_CARD_MARKDOWN_LENGTH = 30_000;
+const MAX_IMAGE_BYTES = 1_024 * 1_024;
+const MAX_IMAGES_PER_CARD = 3;
+const ALLOWED_IMAGE_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+  'image/avif',
+]);
+
+function normalizeId(value: unknown): string {
+  return String(value || '').trim();
+}
+
+function clampTitle(value: unknown, fallback: string, maxLength: number): string {
+  const title = String(value || '').trim();
+  return (title || fallback).slice(0, maxLength);
+}
+
+function clampOptionalText(value: unknown, maxLength: number): string | null {
+  if (value === undefined || value === null) return null;
+  const text = String(value).trim();
+  return text ? text.slice(0, maxLength) : null;
+}
+
+function validateMarkdown(value: unknown): string | Response {
+  const markdown = String(value || '');
+  if (markdown.length > MAX_CARD_MARKDOWN_LENGTH) {
+    return badRequest(`markdown exceeds ${MAX_CARD_MARKDOWN_LENGTH} characters`);
+  }
+  return markdown;
+}
+
+function parseIdArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => normalizeId(entry)).filter(Boolean);
+}
+
+function hasExactIds(actualIds: string[], providedIds: string[]): boolean {
+  if (actualIds.length !== providedIds.length) return false;
+  const uniqueProvided = new Set(providedIds);
+  if (uniqueProvided.size !== providedIds.length) return false;
+  const actualSet = new Set(actualIds);
+  return providedIds.every((id) => actualSet.has(id));
+}
+
+function parseImageDataUrl(dataUrl: string): { mimeType: string; byteLength: number } | null {
+  const trimmed = dataUrl.trim();
+  const match = trimmed.match(/^data:([^;,]+);base64,([A-Za-z0-9+/=]+)$/);
+  if (!match) return null;
+  const mimeType = match[1].toLowerCase();
+  const base64 = match[2];
+  const padding = (base64.match(/=+$/)?.[0].length || 0);
+  const byteLength = Math.floor((base64.length * 3) / 4) - padding;
+  return { mimeType, byteLength };
+}
+
+async function allocateId(env: Bindings, existsSql: string): Promise<string | null> {
+  for (let i = 0; i < 5; i += 1) {
+    const id = urlSafeRandom(12);
+    const exists = await env.DB.prepare(existsSql).bind(id).first();
+    if (!exists) return id;
+  }
+  return null;
+}
+
+async function nextSortOrder(env: Bindings, table: 'boards' | 'board_lists' | 'board_cards' | 'card_images', whereSql: string, values: unknown[]): Promise<number> {
+  const row = await env.DB.prepare(
+    `SELECT COALESCE(MAX(sort_order), -1) AS sort_order FROM ${table} WHERE ${whereSql}`,
+  )
+    .bind(...values)
+    .first<{ sort_order: number | null }>();
+  return Number(row?.sort_order ?? -1) + 1;
+}
+
+async function touchBoard(env: Bindings, boardId: string): Promise<void> {
+  await env.DB.prepare("UPDATE boards SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = ?")
+    .bind(boardId)
+    .run();
+}
+
+async function touchList(env: Bindings, listId: string): Promise<void> {
+  await env.DB.prepare("UPDATE board_lists SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = ?")
+    .bind(listId)
+    .run();
+}
+
+async function touchCard(env: Bindings, cardId: string): Promise<void> {
+  await env.DB.prepare("UPDATE board_cards SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = ?")
+    .bind(cardId)
+    .run();
+}
+
+async function getOwnedBoard(env: Bindings, userId: string, boardId: string): Promise<BoardRow | null> {
+  return (await env.DB.prepare(
+    'SELECT id, user_id, title, description, sort_order, created_at, updated_at FROM boards WHERE id = ? AND user_id = ?',
+  )
+    .bind(boardId, userId)
+    .first()) as BoardRow | null;
+}
+
+async function getOwnedList(env: Bindings, userId: string, listId: string): Promise<BoardListRow | null> {
+  return (await env.DB.prepare(
+    `SELECT l.id, l.board_id, l.title, l.sort_order, l.created_at, l.updated_at
+     FROM board_lists l
+     JOIN boards b ON b.id = l.board_id
+     WHERE l.id = ? AND b.user_id = ?`,
+  )
+    .bind(listId, userId)
+    .first()) as BoardListRow | null;
+}
+
+async function getOwnedCard(env: Bindings, userId: string, cardId: string): Promise<BoardCardRow | null> {
+  return (await env.DB.prepare(
+    `SELECT c.id, c.board_id, c.list_id, c.title, c.markdown, c.sort_order, c.created_at, c.updated_at
+     FROM board_cards c
+     JOIN boards b ON b.id = c.board_id
+     WHERE c.id = ? AND b.user_id = ?`,
+  )
+    .bind(cardId, userId)
+    .first()) as BoardCardRow | null;
+}
+
+async function getOwnedImage(
+  env: Bindings,
+  userId: string,
+  imageId: string,
+): Promise<(CardImageRow & { board_id: string; list_id: string }) | null> {
+  return (await env.DB.prepare(
+    `SELECT i.id, i.card_id, i.mime_type, i.data_url, i.alt_text, i.sort_order, i.created_at, c.board_id, c.list_id
+     FROM card_images i
+     JOIN board_cards c ON c.id = i.card_id
+     JOIN boards b ON b.id = c.board_id
+     WHERE i.id = ? AND b.user_id = ?`,
+  )
+    .bind(imageId, userId)
+    .first()) as (CardImageRow & { board_id: string; list_id: string }) | null;
+}
+
+async function listIdsForBoard(env: Bindings, boardId: string): Promise<string[]> {
+  const rows = await env.DB.prepare(
+    'SELECT id FROM board_lists WHERE board_id = ? ORDER BY sort_order ASC, created_at ASC',
+  )
+    .bind(boardId)
+    .all<{ id: string }>();
+  return (rows.results || []).map((row) => row.id);
+}
+
+async function cardIdsForList(env: Bindings, listId: string, excludeCardId?: string): Promise<string[]> {
+  let sql = 'SELECT id FROM board_cards WHERE list_id = ?';
+  const values: unknown[] = [listId];
+  if (excludeCardId) {
+    sql += ' AND id != ?';
+    values.push(excludeCardId);
+  }
+  sql += ' ORDER BY sort_order ASC, created_at ASC';
+  const rows = await env.DB.prepare(sql).bind(...values).all<{ id: string }>();
+  return (rows.results || []).map((row) => row.id);
+}
+
+async function reorderLists(env: Bindings, boardId: string, listIds: string[]): Promise<void> {
+  for (let index = 0; index < listIds.length; index += 1) {
+    await env.DB.prepare(
+      "UPDATE board_lists SET sort_order = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = ? AND board_id = ?",
+    )
+      .bind(index, listIds[index], boardId)
+      .run();
+  }
+  await touchBoard(env, boardId);
+}
+
+async function reorderCardsInList(env: Bindings, listId: string, cardIds: string[]): Promise<void> {
+  for (let index = 0; index < cardIds.length; index += 1) {
+    await env.DB.prepare(
+      "UPDATE board_cards SET sort_order = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = ? AND list_id = ?",
+    )
+      .bind(index, cardIds[index], listId)
+      .run();
+  }
+}
+
+async function listBoards(env: Bindings, userId: string): Promise<Response> {
+  const rows = await env.DB.prepare(
+    `SELECT b.id, b.title, b.description, b.sort_order, b.created_at, b.updated_at,
+      (SELECT COUNT(*) FROM board_lists l WHERE l.board_id = b.id) AS list_count,
+      (SELECT COUNT(*) FROM board_cards c WHERE c.board_id = b.id) AS card_count
+     FROM boards b
+     WHERE b.user_id = ?
+     ORDER BY b.sort_order ASC, b.updated_at DESC
+     LIMIT 100`,
+  )
+    .bind(userId)
+    .all();
+  return json(rows.results || []);
+}
+
+async function createBoard(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ title?: string; description?: string }>(request);
+  const id = await allocateId(env, 'SELECT id FROM boards WHERE id = ?');
+  if (!id) return badRequest('Failed to allocate board id', 500);
+  const title = clampTitle(body.title, 'Untitled board', MAX_BOARD_TITLE_LENGTH);
+  const description = clampOptionalText(body.description, MAX_BOARD_DESCRIPTION_LENGTH);
+  const sortOrder = await nextSortOrder(env, 'boards', 'user_id = ?', [userId]);
+  await env.DB.prepare(
+    'INSERT INTO boards (id, user_id, title, description, sort_order) VALUES (?, ?, ?, ?, ?)',
+  )
+    .bind(id, userId, title, description, sortOrder)
+    .run();
+  return json({ id });
+}
+
+async function updateBoard(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ id?: string; title?: string; description?: string | null }>(request);
+  const id = normalizeId(body.id);
+  if (!id) return badRequest('id required');
+  const board = await getOwnedBoard(env, userId, id);
+  if (!board) return new Response('Not found', { status: 404 });
+
+  const updates: string[] = [];
+  const values: unknown[] = [];
+
+  if (body.title !== undefined) {
+    updates.push('title = ?');
+    values.push(clampTitle(body.title, 'Untitled board', MAX_BOARD_TITLE_LENGTH));
+  }
+  if (body.description !== undefined) {
+    updates.push('description = ?');
+    values.push(clampOptionalText(body.description, MAX_BOARD_DESCRIPTION_LENGTH));
+  }
+  if (updates.length === 0) return badRequest('No fields to update');
+
+  updates.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')");
+  values.push(id, userId);
+  await env.DB.prepare(`UPDATE boards SET ${updates.join(', ')} WHERE id = ? AND user_id = ?`)
+    .bind(...values)
+    .run();
+  return json({ ok: true });
+}
+
+async function deleteBoard(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ id?: string }>(request);
+  const id = normalizeId(body.id);
+  if (!id) return badRequest('id required');
+  const board = await getOwnedBoard(env, userId, id);
+  if (!board) return new Response('Not found', { status: 404 });
+
+  await env.DB.prepare('DELETE FROM card_images WHERE card_id IN (SELECT id FROM board_cards WHERE board_id = ?)')
+    .bind(id)
+    .run();
+  await env.DB.prepare('DELETE FROM board_cards WHERE board_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM board_lists WHERE board_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM boards WHERE id = ? AND user_id = ?').bind(id, userId).run();
+  return json({ ok: true });
+}
+
+async function getBoard(env: Bindings, userId: string, boardId: string): Promise<Response> {
+  if (!boardId) return badRequest('id required');
+  const board = await getOwnedBoard(env, userId, boardId);
+  if (!board) return new Response('Not found', { status: 404 });
+
+  const listsResult = await env.DB.prepare(
+    'SELECT id, board_id, title, sort_order, created_at, updated_at FROM board_lists WHERE board_id = ? ORDER BY sort_order ASC, created_at ASC',
+  )
+    .bind(boardId)
+    .all<BoardListRow>();
+  const cardsResult = await env.DB.prepare(
+    'SELECT id, board_id, list_id, title, markdown, sort_order, created_at, updated_at FROM board_cards WHERE board_id = ? ORDER BY sort_order ASC, created_at ASC',
+  )
+    .bind(boardId)
+    .all<BoardCardRow>();
+  const imagesResult = await env.DB.prepare(
+    `SELECT i.id, i.card_id, i.mime_type, i.data_url, i.alt_text, i.sort_order, i.created_at
+     FROM card_images i
+     JOIN board_cards c ON c.id = i.card_id
+     WHERE c.board_id = ?
+     ORDER BY i.sort_order ASC, i.created_at ASC`,
+  )
+    .bind(boardId)
+    .all<CardImageRow>();
+
+  const imagesByCard = new Map<string, CardImageRow[]>();
+  for (const image of imagesResult.results || []) {
+    if (!imagesByCard.has(image.card_id)) imagesByCard.set(image.card_id, []);
+    imagesByCard.get(image.card_id)?.push(image);
+  }
+
+  const cardsByList = new Map<string, Array<BoardCardRow & { images: CardImageRow[] }>>();
+  for (const card of cardsResult.results || []) {
+    if (!cardsByList.has(card.list_id)) cardsByList.set(card.list_id, []);
+    cardsByList.get(card.list_id)?.push({
+      ...card,
+      images: imagesByCard.get(card.id) || [],
+    });
+  }
+
+  return json({
+    board,
+    lists: (listsResult.results || []).map((list) => ({
+      ...list,
+      cards: cardsByList.get(list.id) || [],
+    })),
+  });
+}
+
+async function createList(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ board_id?: string; title?: string }>(request);
+  const boardId = normalizeId(body.board_id);
+  if (!boardId) return badRequest('board_id required');
+  const board = await getOwnedBoard(env, userId, boardId);
+  if (!board) return new Response('Not found', { status: 404 });
+
+  const id = await allocateId(env, 'SELECT id FROM board_lists WHERE id = ?');
+  if (!id) return badRequest('Failed to allocate list id', 500);
+  const title = clampTitle(body.title, 'Untitled list', MAX_LIST_TITLE_LENGTH);
+  const sortOrder = await nextSortOrder(env, 'board_lists', 'board_id = ?', [boardId]);
+  await env.DB.prepare(
+    'INSERT INTO board_lists (id, board_id, title, sort_order) VALUES (?, ?, ?, ?)',
+  )
+    .bind(id, boardId, title, sortOrder)
+    .run();
+  await touchBoard(env, boardId);
+  return json({ id });
+}
+
+async function updateList(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ id?: string; title?: string }>(request);
+  const id = normalizeId(body.id);
+  if (!id) return badRequest('id required');
+  const list = await getOwnedList(env, userId, id);
+  if (!list) return new Response('Not found', { status: 404 });
+  await env.DB.prepare(
+    "UPDATE board_lists SET title = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = ?",
+  )
+    .bind(clampTitle(body.title, 'Untitled list', MAX_LIST_TITLE_LENGTH), id)
+    .run();
+  await touchBoard(env, list.board_id);
+  return json({ ok: true });
+}
+
+async function deleteList(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ id?: string }>(request);
+  const id = normalizeId(body.id);
+  if (!id) return badRequest('id required');
+  const list = await getOwnedList(env, userId, id);
+  if (!list) return new Response('Not found', { status: 404 });
+
+  await env.DB.prepare('DELETE FROM card_images WHERE card_id IN (SELECT id FROM board_cards WHERE list_id = ?)')
+    .bind(id)
+    .run();
+  await env.DB.prepare('DELETE FROM board_cards WHERE list_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM board_lists WHERE id = ?').bind(id).run();
+
+  const remainingIds = await listIdsForBoard(env, list.board_id);
+  await reorderLists(env, list.board_id, remainingIds);
+  return json({ ok: true });
+}
+
+async function reorderBoardLists(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ board_id?: string; list_ids?: string[] }>(request);
+  const boardId = normalizeId(body.board_id);
+  if (!boardId) return badRequest('board_id required');
+  const board = await getOwnedBoard(env, userId, boardId);
+  if (!board) return new Response('Not found', { status: 404 });
+  const listIds = parseIdArray(body.list_ids);
+  const actualIds = await listIdsForBoard(env, boardId);
+  if (!hasExactIds(actualIds, listIds)) return badRequest('list_ids do not match the board lists');
+  await reorderLists(env, boardId, listIds);
+  return json({ ok: true });
+}
+
+async function createCard(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ list_id?: string; title?: string; markdown?: string }>(request);
+  const listId = normalizeId(body.list_id);
+  if (!listId) return badRequest('list_id required');
+  const list = await getOwnedList(env, userId, listId);
+  if (!list) return new Response('Not found', { status: 404 });
+  const markdown = validateMarkdown(body.markdown);
+  if (markdown instanceof Response) return markdown;
+  const id = await allocateId(env, 'SELECT id FROM board_cards WHERE id = ?');
+  if (!id) return badRequest('Failed to allocate card id', 500);
+  const sortOrder = await nextSortOrder(env, 'board_cards', 'list_id = ?', [listId]);
+  await env.DB.prepare(
+    'INSERT INTO board_cards (id, board_id, list_id, title, markdown, sort_order) VALUES (?, ?, ?, ?, ?, ?)',
+  )
+    .bind(id, list.board_id, listId, clampTitle(body.title, 'Untitled card', MAX_CARD_TITLE_LENGTH), markdown, sortOrder)
+    .run();
+  await touchList(env, listId);
+  await touchBoard(env, list.board_id);
+  return json({ id });
+}
+
+async function updateCard(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ id?: string; title?: string; markdown?: string }>(request);
+  const id = normalizeId(body.id);
+  if (!id) return badRequest('id required');
+  const card = await getOwnedCard(env, userId, id);
+  if (!card) return new Response('Not found', { status: 404 });
+
+  const updates: string[] = [];
+  const values: unknown[] = [];
+
+  if (body.title !== undefined) {
+    updates.push('title = ?');
+    values.push(clampTitle(body.title, 'Untitled card', MAX_CARD_TITLE_LENGTH));
+  }
+  if (body.markdown !== undefined) {
+    const markdown = validateMarkdown(body.markdown);
+    if (markdown instanceof Response) return markdown;
+    updates.push('markdown = ?');
+    values.push(markdown);
+  }
+  if (updates.length === 0) return badRequest('No fields to update');
+
+  updates.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')");
+  values.push(id);
+  await env.DB.prepare(`UPDATE board_cards SET ${updates.join(', ')} WHERE id = ?`)
+    .bind(...values)
+    .run();
+  await touchList(env, card.list_id);
+  await touchBoard(env, card.board_id);
+  return json({ ok: true });
+}
+
+async function deleteCard(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ id?: string }>(request);
+  const id = normalizeId(body.id);
+  if (!id) return badRequest('id required');
+  const card = await getOwnedCard(env, userId, id);
+  if (!card) return new Response('Not found', { status: 404 });
+
+  await env.DB.prepare('DELETE FROM card_images WHERE card_id = ?').bind(id).run();
+  await env.DB.prepare('DELETE FROM board_cards WHERE id = ?').bind(id).run();
+  const remainingIds = await cardIdsForList(env, card.list_id);
+  await reorderCardsInList(env, card.list_id, remainingIds);
+  await touchList(env, card.list_id);
+  await touchBoard(env, card.board_id);
+  return json({ ok: true });
+}
+
+async function reorderCards(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ list_id?: string; card_ids?: string[] }>(request);
+  const listId = normalizeId(body.list_id);
+  if (!listId) return badRequest('list_id required');
+  const list = await getOwnedList(env, userId, listId);
+  if (!list) return new Response('Not found', { status: 404 });
+  const cardIds = parseIdArray(body.card_ids);
+  const actualIds = await cardIdsForList(env, listId);
+  if (!hasExactIds(actualIds, cardIds)) return badRequest('card_ids do not match the list cards');
+  await reorderCardsInList(env, listId, cardIds);
+  await touchList(env, listId);
+  await touchBoard(env, list.board_id);
+  return json({ ok: true });
+}
+
+async function moveCard(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{
+    card_id?: string;
+    to_list_id?: string;
+    source_card_ids?: string[];
+    destination_card_ids?: string[];
+  }>(request);
+  const cardId = normalizeId(body.card_id);
+  const toListId = normalizeId(body.to_list_id);
+  if (!cardId) return badRequest('card_id required');
+  if (!toListId) return badRequest('to_list_id required');
+
+  const card = await getOwnedCard(env, userId, cardId);
+  if (!card) return new Response('Not found', { status: 404 });
+  const destinationList = await getOwnedList(env, userId, toListId);
+  if (!destinationList) return new Response('Not found', { status: 404 });
+  if (destinationList.board_id !== card.board_id) {
+    return badRequest('cannot move cards across boards');
+  }
+
+  const destinationCardIds = parseIdArray(body.destination_card_ids);
+  if (destinationList.id === card.list_id) {
+    const actualIds = await cardIdsForList(env, card.list_id);
+    if (!hasExactIds(actualIds, destinationCardIds) || !destinationCardIds.includes(card.id)) {
+      return badRequest('destination_card_ids do not match the list cards');
+    }
+    await reorderCardsInList(env, card.list_id, destinationCardIds);
+    await touchList(env, card.list_id);
+    await touchBoard(env, card.board_id);
+    return json({ ok: true });
+  }
+
+  const sourceCardIds = parseIdArray(body.source_card_ids);
+  const actualSourceIds = await cardIdsForList(env, card.list_id, card.id);
+  const actualDestinationIds = await cardIdsForList(env, destinationList.id);
+  if (!hasExactIds(actualSourceIds, sourceCardIds)) {
+    return badRequest('source_card_ids do not match the source list cards');
+  }
+  if (!destinationCardIds.includes(card.id)) {
+    return badRequest('destination_card_ids must include the moved card');
+  }
+  if (!hasExactIds([...actualDestinationIds, card.id], destinationCardIds)) {
+    return badRequest('destination_card_ids do not match the destination list cards');
+  }
+
+  await env.DB.prepare(
+    "UPDATE board_cards SET list_id = ?, sort_order = -1, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = ?",
+  )
+    .bind(destinationList.id, card.id)
+    .run();
+  await reorderCardsInList(env, card.list_id, sourceCardIds);
+  await reorderCardsInList(env, destinationList.id, destinationCardIds);
+  await touchList(env, card.list_id);
+  await touchList(env, destinationList.id);
+  await touchBoard(env, card.board_id);
+  return json({ ok: true });
+}
+
+async function addCardImage(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ card_id?: string; data_url?: string; alt_text?: string }>(request);
+  const cardId = normalizeId(body.card_id);
+  if (!cardId) return badRequest('card_id required');
+  const card = await getOwnedCard(env, userId, cardId);
+  if (!card) return new Response('Not found', { status: 404 });
+  const dataUrl = String(body.data_url || '').trim();
+  if (!dataUrl) return badRequest('data_url required');
+  const parsed = parseImageDataUrl(dataUrl);
+  if (!parsed) return badRequest('data_url must be a base64 image data URL');
+  if (!ALLOWED_IMAGE_MIME_TYPES.has(parsed.mimeType)) {
+    return badRequest('unsupported image type');
+  }
+  if (parsed.byteLength > MAX_IMAGE_BYTES) {
+    return badRequest(`image exceeds ${MAX_IMAGE_BYTES} bytes`);
+  }
+  const countRow = await env.DB.prepare('SELECT COUNT(*) AS count FROM card_images WHERE card_id = ?')
+    .bind(cardId)
+    .first<{ count: number | string }>();
+  const count = Number(countRow?.count || 0);
+  if (count >= MAX_IMAGES_PER_CARD) {
+    return badRequest(`cards can have at most ${MAX_IMAGES_PER_CARD} images`);
+  }
+  const id = await allocateId(env, 'SELECT id FROM card_images WHERE id = ?');
+  if (!id) return badRequest('Failed to allocate image id', 500);
+  const sortOrder = await nextSortOrder(env, 'card_images', 'card_id = ?', [cardId]);
+  await env.DB.prepare(
+    'INSERT INTO card_images (id, card_id, mime_type, data_url, alt_text, sort_order) VALUES (?, ?, ?, ?, ?, ?)',
+  )
+    .bind(id, cardId, parsed.mimeType, dataUrl, clampOptionalText(body.alt_text, 200), sortOrder)
+    .run();
+  await touchCard(env, cardId);
+  await touchList(env, card.list_id);
+  await touchBoard(env, card.board_id);
+  return json({ id });
+}
+
+async function deleteCardImage(request: Request, env: Bindings, userId: string): Promise<Response> {
+  const body = await readJson<{ id?: string }>(request);
+  const id = normalizeId(body.id);
+  if (!id) return badRequest('id required');
+  const image = await getOwnedImage(env, userId, id);
+  if (!image) return new Response('Not found', { status: 404 });
+  await env.DB.prepare('DELETE FROM card_images WHERE id = ?').bind(id).run();
+
+  const remainingRows = await env.DB.prepare(
+    'SELECT id FROM card_images WHERE card_id = ? ORDER BY sort_order ASC, created_at ASC',
+  )
+    .bind(image.card_id)
+    .all<{ id: string }>();
+  const remainingIds = (remainingRows.results || []).map((row) => row.id);
+  for (let index = 0; index < remainingIds.length; index += 1) {
+    await env.DB.prepare('UPDATE card_images SET sort_order = ? WHERE id = ?')
+      .bind(index, remainingIds[index])
+      .run();
+  }
+
+  await touchCard(env, image.card_id);
+  await touchList(env, image.list_id);
+  await touchBoard(env, image.board_id);
+  return json({ ok: true });
+}
+
+export async function handleBoardsApi(
+  request: Request,
+  env: Bindings,
+  url: URL,
+): Promise<HandlerResult> {
+  const path = url.pathname;
+
+  if (path === '/api/boards/list' && request.method === 'GET') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return listBoards(env, user.id);
+  }
+
+  if (path === '/api/boards/create' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return createBoard(request, env, user.id);
+  }
+
+  if (path === '/api/boards/update' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return updateBoard(request, env, user.id);
+  }
+
+  if (path === '/api/boards/delete' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return deleteBoard(request, env, user.id);
+  }
+
+  if (path === '/api/boards/get' && request.method === 'GET') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return getBoard(env, user.id, normalizeId(url.searchParams.get('id')));
+  }
+
+  if (path === '/api/boards/lists/create' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return createList(request, env, user.id);
+  }
+
+  if (path === '/api/boards/lists/update' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return updateList(request, env, user.id);
+  }
+
+  if (path === '/api/boards/lists/delete' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return deleteList(request, env, user.id);
+  }
+
+  if (path === '/api/boards/lists/reorder' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return reorderBoardLists(request, env, user.id);
+  }
+
+  if (path === '/api/boards/cards/create' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return createCard(request, env, user.id);
+  }
+
+  if (path === '/api/boards/cards/update' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return updateCard(request, env, user.id);
+  }
+
+  if (path === '/api/boards/cards/delete' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return deleteCard(request, env, user.id);
+  }
+
+  if (path === '/api/boards/cards/reorder' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return reorderCards(request, env, user.id);
+  }
+
+  if (path === '/api/boards/cards/move' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return moveCard(request, env, user.id);
+  }
+
+  if (path === '/api/boards/cards/images/add' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return addCardImage(request, env, user.id);
+  }
+
+  if (path === '/api/boards/cards/images/delete' && request.method === 'POST') {
+    const user = await requireUser(request, env);
+    if (user instanceof Response) return user;
+    return deleteCardImage(request, env, user.id);
+  }
+
+  return null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { handlePagesApi } from './pages';
 import { handlePastebinApi, handlePastebinPage } from './pastebin';
 import { handleGoalApi } from './goals';
 import { handleTodoApi } from './todo';
+import { handleBoardsApi } from './boards';
 import { handleTranscriptApi } from './routes/transcript';
 import { serveStatic } from './static';
 import type { Bindings, WorkerExport } from './types';
@@ -30,6 +31,9 @@ export default {
 
     const todoApiResponse = await handleTodoApi(request, bindings, url);
     if (todoApiResponse) return todoApiResponse;
+
+    const boardsApiResponse = await handleBoardsApi(request, bindings, url);
+    if (boardsApiResponse) return boardsApiResponse;
 
     const transcriptResponse = await handleTranscriptApi(request, bindings, url);
     if (transcriptResponse) return transcriptResponse;

--- a/src/internal-test.ts
+++ b/src/internal-test.ts
@@ -32,6 +32,50 @@ async function ensureSchema(env: Bindings): Promise<void> {
       updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
     )
   `).run();
+  await env.DB.prepare(`
+    CREATE TABLE IF NOT EXISTS boards (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      description TEXT,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+    )
+  `).run();
+  await env.DB.prepare(`
+    CREATE TABLE IF NOT EXISTS board_lists (
+      id TEXT PRIMARY KEY,
+      board_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+    )
+  `).run();
+  await env.DB.prepare(`
+    CREATE TABLE IF NOT EXISTS board_cards (
+      id TEXT PRIMARY KEY,
+      board_id TEXT NOT NULL,
+      list_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      markdown TEXT NOT NULL DEFAULT '',
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+    )
+  `).run();
+  await env.DB.prepare(`
+    CREATE TABLE IF NOT EXISTS card_images (
+      id TEXT PRIMARY KEY,
+      card_id TEXT NOT NULL,
+      mime_type TEXT NOT NULL,
+      data_url TEXT NOT NULL,
+      alt_text TEXT,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+    )
+  `).run();
 }
 
 export async function handleInternalTestRoutes(request: Request, env: Bindings, url: URL): Promise<HandlerResult> {
@@ -56,4 +100,3 @@ export async function handleInternalTestRoutes(request: Request, env: Bindings, 
 
   return json({ userId, token });
 }
-

--- a/src/static.ts
+++ b/src/static.ts
@@ -17,6 +17,8 @@ const PRETTY_ROUTES: Record<string, string> = {
   '/csv-editor/': '/csv-editor.html',
   '/todo': '/todo.html',
   '/todo/': '/todo.html',
+  '/boards': '/boards.html',
+  '/boards/': '/boards.html',
   '/date': '/date.html',
   '/date/': '/date.html',
   '/llm-cost': '/llm-cost.html',

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -24,6 +24,7 @@ describe('Tools index and Markdown viewer', () => {
     expect(body).toContain('href="/area-code"');
     expect(body).toContain('href="/format-tools"');
     expect(body).toContain('href="/csv-editor"');
+    expect(body).toContain('href="/boards"');
   });
 
   it('serves markdown viewer at /markdown (unit)', async () => {
@@ -298,8 +299,28 @@ describe('Pretty routes and Pages API', () => {
     expect(body).toContain('<title>To-Do List</title>');
   });
 
+  it('serves boards at /boards (unit)', async () => {
+    const request = new IncomingRequest('http://example.com/boards');
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+    const body = await response.text();
+    expect(body).toContain('<title>Boards</title>');
+    expect(body).toContain('id="boardCanvas"');
+  });
+
   it('rejects unauthenticated pages list', async () => {
     const request = new IncomingRequest('http://example.com/api/pages/list?tool=markdown');
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects unauthenticated boards list', async () => {
+    const request = new IncomingRequest('http://example.com/api/boards/list');
     const ctx = createExecutionContext();
     const response = await worker.fetch(request, env, ctx);
     await waitOnExecutionContext(ctx);
@@ -354,5 +375,169 @@ describe('Pretty routes and Pages API', () => {
     expect(page.id).toBe(created.id);
     expect(page.tool).toBe('markdown');
     expect(page.content).toBe('# Hello');
+  });
+
+  it('creates, reorders, and protects boards data (unit)', async () => {
+    (env as any).INTERNAL_TEST_KEY = 'k';
+
+    const seedOneReq = new IncomingRequest('http://example.com/api/_internal/seed', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-internal-key': 'k' },
+      body: JSON.stringify({ email: 'boards-one@example.com', name: 'Boards One' }),
+    });
+    const seedOneCtx = createExecutionContext();
+    const seedOneRes = await worker.fetch(seedOneReq, env, seedOneCtx);
+    await waitOnExecutionContext(seedOneCtx);
+    expect(seedOneRes.status).toBe(200);
+    const userOne = await seedOneRes.json<any>();
+    const tokenOne = String(userOne.token || '');
+
+    const seedTwoReq = new IncomingRequest('http://example.com/api/_internal/seed', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-internal-key': 'k' },
+      body: JSON.stringify({ email: 'boards-two@example.com', name: 'Boards Two' }),
+    });
+    const seedTwoCtx = createExecutionContext();
+    const seedTwoRes = await worker.fetch(seedTwoReq, env, seedTwoCtx);
+    await waitOnExecutionContext(seedTwoCtx);
+    expect(seedTwoRes.status).toBe(200);
+    const userTwo = await seedTwoRes.json<any>();
+    const tokenTwo = String(userTwo.token || '');
+
+    const createBoardReq = new IncomingRequest('http://example.com/api/boards/create', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `wt_session=${tokenOne}` },
+      body: JSON.stringify({ title: 'Project Alpha', description: 'Initial board' }),
+    });
+    const createBoardCtx = createExecutionContext();
+    const createBoardRes = await worker.fetch(createBoardReq, env, createBoardCtx);
+    await waitOnExecutionContext(createBoardCtx);
+    expect(createBoardRes.status).toBe(200);
+    const createdBoard = await createBoardRes.json<any>();
+    expect(typeof createdBoard.id).toBe('string');
+
+    const listBoardsReq = new IncomingRequest('http://example.com/api/boards/list', {
+      headers: { cookie: `wt_session=${tokenOne}` },
+    });
+    const listBoardsCtx = createExecutionContext();
+    const listBoardsRes = await worker.fetch(listBoardsReq, env, listBoardsCtx);
+    await waitOnExecutionContext(listBoardsCtx);
+    expect(listBoardsRes.status).toBe(200);
+    const boards = await listBoardsRes.json<any[]>();
+    expect(boards.some((board) => board.id === createdBoard.id)).toBe(true);
+
+    const createTodoListReq = new IncomingRequest('http://example.com/api/boards/lists/create', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `wt_session=${tokenOne}` },
+      body: JSON.stringify({ board_id: createdBoard.id, title: 'To do' }),
+    });
+    const createTodoListCtx = createExecutionContext();
+    const createTodoListRes = await worker.fetch(createTodoListReq, env, createTodoListCtx);
+    await waitOnExecutionContext(createTodoListCtx);
+    expect(createTodoListRes.status).toBe(200);
+    const todoList = await createTodoListRes.json<any>();
+
+    const createDoingListReq = new IncomingRequest('http://example.com/api/boards/lists/create', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `wt_session=${tokenOne}` },
+      body: JSON.stringify({ board_id: createdBoard.id, title: 'Doing' }),
+    });
+    const createDoingListCtx = createExecutionContext();
+    const createDoingListRes = await worker.fetch(createDoingListReq, env, createDoingListCtx);
+    await waitOnExecutionContext(createDoingListCtx);
+    expect(createDoingListRes.status).toBe(200);
+    const doingList = await createDoingListRes.json<any>();
+
+    const createCardReq = new IncomingRequest('http://example.com/api/boards/cards/create', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `wt_session=${tokenOne}` },
+      body: JSON.stringify({ list_id: todoList.id, title: 'Write spec', markdown: '# Ready' }),
+    });
+    const createCardCtx = createExecutionContext();
+    const createCardRes = await worker.fetch(createCardReq, env, createCardCtx);
+    await waitOnExecutionContext(createCardCtx);
+    expect(createCardRes.status).toBe(200);
+    const cardOne = await createCardRes.json<any>();
+
+    const createCardTwoReq = new IncomingRequest('http://example.com/api/boards/cards/create', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `wt_session=${tokenOne}` },
+      body: JSON.stringify({ list_id: todoList.id, title: 'Ship feature', markdown: 'Needs polish' }),
+    });
+    const createCardTwoCtx = createExecutionContext();
+    const createCardTwoRes = await worker.fetch(createCardTwoReq, env, createCardTwoCtx);
+    await waitOnExecutionContext(createCardTwoCtx);
+    expect(createCardTwoRes.status).toBe(200);
+    const cardTwo = await createCardTwoRes.json<any>();
+
+    const moveCardReq = new IncomingRequest('http://example.com/api/boards/cards/move', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `wt_session=${tokenOne}` },
+      body: JSON.stringify({
+        card_id: cardOne.id,
+        to_list_id: doingList.id,
+        source_card_ids: [cardTwo.id],
+        destination_card_ids: [cardOne.id],
+      }),
+    });
+    const moveCardCtx = createExecutionContext();
+    const moveCardRes = await worker.fetch(moveCardReq, env, moveCardCtx);
+    await waitOnExecutionContext(moveCardCtx);
+    expect(moveCardRes.status).toBe(200);
+
+    const addImageReq = new IncomingRequest('http://example.com/api/boards/cards/images/add', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `wt_session=${tokenOne}` },
+      body: JSON.stringify({
+        card_id: cardOne.id,
+        data_url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9s2m30QAAAAASUVORK5CYII=',
+        alt_text: 'pixel',
+      }),
+    });
+    const addImageCtx = createExecutionContext();
+    const addImageRes = await worker.fetch(addImageReq, env, addImageCtx);
+    await waitOnExecutionContext(addImageCtx);
+    expect(addImageRes.status).toBe(200);
+    const addedImage = await addImageRes.json<any>();
+    expect(typeof addedImage.id).toBe('string');
+
+    const oversizedImageReq = new IncomingRequest('http://example.com/api/boards/cards/images/add', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `wt_session=${tokenOne}` },
+      body: JSON.stringify({
+        card_id: cardOne.id,
+        data_url: 'data:image/png;base64,' + 'A'.repeat(1_500_000),
+      }),
+    });
+    const oversizedImageCtx = createExecutionContext();
+    const oversizedImageRes = await worker.fetch(oversizedImageReq, env, oversizedImageCtx);
+    await waitOnExecutionContext(oversizedImageCtx);
+    expect(oversizedImageRes.status).toBe(400);
+
+    const getBoardReq = new IncomingRequest(`http://example.com/api/boards/get?id=${encodeURIComponent(createdBoard.id)}`, {
+      headers: { cookie: `wt_session=${tokenOne}` },
+    });
+    const getBoardCtx = createExecutionContext();
+    const getBoardRes = await worker.fetch(getBoardReq, env, getBoardCtx);
+    await waitOnExecutionContext(getBoardCtx);
+    expect(getBoardRes.status).toBe(200);
+    const hydratedBoard = await getBoardRes.json<any>();
+    expect(hydratedBoard.board.id).toBe(createdBoard.id);
+    expect(hydratedBoard.lists).toHaveLength(2);
+    const hydratedDoing = hydratedBoard.lists.find((list) => list.id === doingList.id);
+    const hydratedTodo = hydratedBoard.lists.find((list) => list.id === todoList.id);
+    expect(hydratedDoing.cards).toHaveLength(1);
+    expect(hydratedDoing.cards[0].id).toBe(cardOne.id);
+    expect(hydratedDoing.cards[0].images).toHaveLength(1);
+    expect(hydratedTodo.cards).toHaveLength(1);
+    expect(hydratedTodo.cards[0].id).toBe(cardTwo.id);
+
+    const forbiddenGetReq = new IncomingRequest(`http://example.com/api/boards/get?id=${encodeURIComponent(createdBoard.id)}`, {
+      headers: { cookie: `wt_session=${tokenTwo}` },
+    });
+    const forbiddenGetCtx = createExecutionContext();
+    const forbiddenGetRes = await worker.fetch(forbiddenGetReq, env, forbiddenGetCtx);
+    await waitOnExecutionContext(forbiddenGetCtx);
+    expect(forbiddenGetRes.status).toBe(404);
   });
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -285,6 +285,18 @@ describe('Tools index and Markdown viewer', () => {
     const json = await response.json();
     expect(json.error).toBe('url required');
   });
+
+  it('uses the request host for Google OAuth callback when needed (unit)', async () => {
+    const request = new IncomingRequest('https://tools.example.com/auth/google/login?returnTo=%2Fboards');
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(response.status).toBe(302);
+    const location = response.headers.get('location') || '';
+    const oauthUrl = new URL(location);
+    expect(oauthUrl.origin).toBe('https://accounts.google.com');
+    expect(oauthUrl.searchParams.get('redirect_uri')).toBe('https://tools.example.com/auth/google/callback');
+  });
 });
 
 describe('Pretty routes and Pages API', () => {


### PR DESCRIPTION
## Summary
- Add a private Trello-style boards tool backed by D1 and the existing Google OAuth session flow.

## Changes
- Add a D1 migration and a new Worker API module for board, list, card, and card image CRUD plus drag-and-drop reorder endpoints.
- Add the `/boards` UI with board switching, Markdown card editing and preview, drag-and-drop list and card movement, and dropped image uploads stored in D1.
- Wire the new route into static routing and shared navigation, and extend internal test seeding for the new D1 tables.
- Add worker tests covering auth enforcement, board creation, nested board hydration, card moves, image size validation, and cross-user access protection.

## Testing
- `npm test`

## Notes
- Apply `migrations/0007_boards.sql` before deployment.
- `npx tsc -p tsconfig.json --noEmit` still reports pre-existing issues in `src/goals.ts` and `src/utils/html.ts`.
