### PR TITLE
Update Markdown viewer UI

### DIFF
--- a/public/markdown.html
+++ b/public/markdown.html
@@ -1,95 +1,829 @@
 <!doctype html>
 <html lang="en">
   <head>
-	    <meta charset="utf-8" />
-	    <meta name="viewport" content="width=device-width, initial-scale=1" />
-	    <title>Markdown Viewer</title>
-	    <link rel="stylesheet" href="/shared/toolkit.css" />
-	    <script defer src="/shared/toolkit.js"></script>
-	    <style>
-	      * { box-sizing: border-box; }
-	      html, body { height: 100%; margin: 0; }
-	      body { background: transparent; color: var(--fg); font-family: inherit; }
-      .app-header {
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Markdown Viewer</title>
+    <link rel="stylesheet" href="/shared/toolkit.css" />
+    <script defer src="/shared/toolkit.js"></script>
+    <style>
+      * { box-sizing: border-box; }
+      html, body { min-height: 100%; margin: 0; }
+      body.wt {
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(246, 248, 252, 0.94)),
+          var(--wt-bg);
+        color: #11182c;
+      }
+      [data-theme='dark'] body.wt {
+        background:
+          linear-gradient(180deg, rgba(9, 14, 30, 0.92), rgba(7, 11, 22, 0.98)),
+          var(--wt-bg);
+        color: var(--wt-fg);
+      }
+      body[data-wt-tool='markdown'] .wt-header {
+        margin: 8px auto 0;
+        width: min(calc(100% - 32px), 1880px);
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 10px;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+        background: rgba(255, 255, 255, 0.9);
+      }
+      [data-theme='dark'] body[data-wt-tool='markdown'] .wt-header {
+        border-color: rgba(226, 237, 255, 0.12);
+        background: rgba(15, 23, 42, 0.9);
+      }
+      body[data-wt-tool='markdown'] .wt-header-inner {
+        max-width: none;
+        padding: 12px 18px;
+      }
+      body[data-wt-tool='markdown'] .wt-logo-link {
+        width: 34px;
+        height: 34px;
+        border-radius: 8px;
+        color: #2563eb;
+        background: #eef4ff;
+      }
+      body[data-wt-tool='markdown'] .wt-logo-link::after {
+        content: 'M';
+        font-weight: 800;
+        font-size: 0.9rem;
+      }
+      body[data-wt-tool='markdown'] .wt-logo { display: none; }
+      body[data-wt-tool='markdown'] .wt-toolname {
+        border-left: 0;
+        padding-left: 0;
+        color: inherit;
+        font-size: 1rem;
+        font-weight: 750;
+      }
+      body[data-wt-tool='markdown'] .wt-actions > a[title='Home'] { display: none; }
+      body[data-wt-tool='markdown'] .wt-btn {
+        min-height: 34px;
+        border-radius: 8px;
+        border-style: solid;
+        background: #fff;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+      }
+      [data-theme='dark'] body[data-wt-tool='markdown'] .wt-btn { background: rgba(15, 23, 42, 0.8); }
+      body[data-wt-tool='markdown'] #wtToggleTheme::before { content: '*'; }
+      body[data-wt-tool='markdown'] #wtToggleTheme {
+        gap: 9px;
+        min-width: 106px;
+        justify-content: center;
+      }
+      .md-shell {
+        width: min(calc(100% - 32px), 1880px);
+        margin: 12px auto 22px;
+        display: grid;
+        grid-template-columns: 450px minmax(0, 1fr);
+        gap: 24px;
+        align-items: start;
+      }
+      .md-sidebar {
+        display: grid;
+        gap: 10px;
+      }
+      .md-card,
+      .md-reader {
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.92);
+        box-shadow: 0 14px 40px rgba(15, 23, 42, 0.08);
+      }
+      [data-theme='dark'] .md-card,
+      [data-theme='dark'] .md-reader {
+        border-color: rgba(226, 237, 255, 0.1);
+        background: rgba(15, 23, 42, 0.88);
+        box-shadow: 0 20px 48px rgba(0, 0, 0, 0.34);
+      }
+      .md-card { padding: 20px; }
+      .md-card-title {
+        margin: 0;
+        font-size: 0.95rem;
+        font-weight: 800;
+        letter-spacing: 0;
+      }
+      .md-card-head,
+      .md-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .md-doc-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .md-icon-btn,
+      .md-text-btn,
+      .md-select,
+      .md-field {
+        appearance: none;
+        border: 1px solid rgba(15, 23, 42, 0.12);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.95);
+        color: inherit;
+        font: inherit;
+      }
+      [data-theme='dark'] .md-icon-btn,
+      [data-theme='dark'] .md-text-btn,
+      [data-theme='dark'] .md-select,
+      [data-theme='dark'] .md-field {
+        border-color: rgba(226, 237, 255, 0.13);
+        background: rgba(7, 11, 22, 0.44);
+      }
+      .md-icon-btn,
+      .md-text-btn {
+        min-height: 34px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 8px 10px;
+        cursor: pointer;
+      }
+      .md-icon-btn {
+        width: 38px;
+        padding: 0;
+      }
+      .md-text-btn {
+        min-width: 88px;
+        font-size: 0.88rem;
+      }
+      .md-text-btn.primary {
+        border-color: rgba(37, 99, 235, 0.28);
+        color: #1d4ed8;
+        background: #f7fbff;
+      }
+      [data-theme='dark'] .md-text-btn.primary {
+        color: #93c5fd;
+        background: rgba(37, 99, 235, 0.12);
+      }
+      .md-text-btn.danger { color: var(--wt-danger); }
+      .md-icon {
+        width: 18px;
+        height: 18px;
+        display: inline-block;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+      .md-search-wrap {
+        position: relative;
+        margin-top: 14px;
+      }
+      .md-search-wrap .md-icon {
+        position: absolute;
+        top: 50%;
+        left: 12px;
+        width: 17px;
+        height: 17px;
+        transform: translateY(-50%);
+        color: #667085;
+      }
+      .md-field {
+        width: 100%;
+        min-height: 38px;
+        padding: 8px 46px 8px 38px;
+        outline: none;
+      }
+      .md-kbd {
+        position: absolute;
+        top: 50%;
+        right: 10px;
+        transform: translateY(-50%);
+        min-width: 28px;
+        padding: 2px 5px;
+        border-radius: 5px;
+        background: rgba(15, 23, 42, 0.06);
+        color: #667085;
+        text-align: center;
+        font-size: 0.75rem;
+        font-weight: 700;
+      }
+      .md-doc-list {
+        display: grid;
+        gap: 8px;
+        margin-top: 12px;
+      }
+      .md-doc-item {
+        width: 100%;
+        display: grid;
+        grid-template-columns: 30px minmax(0, 1fr) 24px;
+        gap: 10px;
+        align-items: center;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 7px;
+        background: #fff;
+        color: inherit;
+        padding: 11px 10px;
+        text-align: left;
+        cursor: pointer;
+      }
+      .md-doc-item:hover { border-color: rgba(37, 99, 235, 0.32); }
+      .md-doc-item.active {
+        border-color: #2563eb;
+        background: #eef5ff;
+        box-shadow: inset 3px 0 0 #2563eb;
+      }
+      [data-theme='dark'] .md-doc-item {
+        border-color: rgba(226, 237, 255, 0.1);
+        background: rgba(7, 11, 22, 0.3);
+      }
+      [data-theme='dark'] .md-doc-item.active {
+        border-color: #60a5fa;
+        background: rgba(37, 99, 235, 0.16);
+      }
+      .md-doc-icon {
+        width: 24px;
+        height: 24px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 5px;
+        color: #2563eb;
+        background: #e8f0ff;
+      }
+      .md-doc-title {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 750;
+      }
+      .md-doc-subtitle {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        margin-top: 2px;
+        color: #667085;
+        font-size: 0.78rem;
+      }
+      [data-theme='dark'] .md-doc-subtitle,
+      [data-theme='dark'] .md-muted { color: var(--wt-muted); }
+      .md-more-dots {
+        color: #667085;
+        font-weight: 900;
+        letter-spacing: 1px;
+      }
+      .md-link-btn {
+        appearance: none;
+        border: 0;
+        background: transparent;
+        color: #2563eb;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin: 12px auto 0;
+        padding: 4px 8px;
+        cursor: pointer;
+        font: inherit;
+        font-size: 0.86rem;
+      }
+      .md-info-grid {
+        display: grid;
+        grid-template-columns: minmax(90px, 0.55fr) minmax(0, 1fr);
+        gap: 8px 18px;
+        margin-top: 18px;
+        font-size: 0.86rem;
+      }
+      .md-info-grid dt {
+        color: #475467;
+        margin: 0;
+      }
+      .md-info-grid dd {
+        margin: 0;
+        min-width: 0;
+        overflow-wrap: anywhere;
+      }
+      .md-segment {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+        margin-top: 16px;
+      }
+      .md-segment button {
+        min-height: 68px;
+        flex-direction: column;
+        gap: 7px;
+      }
+      .md-segment button.active {
+        border-color: #2563eb;
+        box-shadow: inset 0 0 0 1px #2563eb;
+        color: #1d4ed8;
+        background: #f8fbff;
+      }
+      [data-theme='dark'] .md-segment button.active {
+        color: #93c5fd;
+        background: rgba(37, 99, 235, 0.14);
+      }
+      .md-setting-list {
+        display: grid;
+        gap: 10px;
+        margin-top: 16px;
+      }
+      .md-setting-list label {
+        display: grid;
+        grid-template-columns: 1fr minmax(150px, 0.9fr);
+        gap: 12px;
+        align-items: center;
+        font-size: 0.86rem;
+      }
+      .md-select {
+        min-height: 36px;
+        padding: 7px 10px;
+      }
+      .md-stepper {
+        display: grid;
+        grid-template-columns: 36px 1fr 36px;
+        overflow: hidden;
+        border: 1px solid rgba(15, 23, 42, 0.12);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.95);
+      }
+      [data-theme='dark'] .md-stepper {
+        border-color: rgba(226, 237, 255, 0.13);
+        background: rgba(7, 11, 22, 0.44);
+      }
+      .md-stepper button {
+        border: 0;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+        font-size: 1rem;
+      }
+      .md-stepper output {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 34px;
+        border-inline: 1px solid rgba(15, 23, 42, 0.08);
+      }
+      .md-export-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+        margin-top: 16px;
+      }
+      .md-export-grid .wide { grid-column: 1 / -1; }
+      .md-reader {
+        min-width: 0;
+        overflow: hidden;
+      }
+      .md-reader-topbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 18px 34px 10px;
+      }
+      .md-meta-line {
+        min-width: 0;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        color: #475467;
+        font-size: 0.88rem;
+      }
+      .md-meta-line span:last-child {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .md-reader-actions {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .md-save-state {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        color: #0f766e;
+        white-space: nowrap;
+        font-size: 0.84rem;
+      }
+      .md-reader-grid {
+        display: grid;
+        grid-template-columns: minmax(320px, 0.82fr) minmax(0, 1fr);
+        gap: 0;
+        min-height: calc(100vh - 134px);
+      }
+      .md-source-wrap {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        border-top: 1px solid rgba(15, 23, 42, 0.08);
+        border-right: 1px solid rgba(15, 23, 42, 0.08);
+        background: #fbfcff;
+      }
+      [data-theme='dark'] .md-source-wrap {
+        border-color: rgba(226, 237, 255, 0.1);
+        background: rgba(7, 11, 22, 0.3);
+      }
+      .md-source-head {
+        min-height: 46px;
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 8px;
-        padding: 0.85rem 1.25rem;
-        border-bottom: 1px solid var(--border);
-        background: var(--header-bg);
-        color: var(--header-fg);
-        position: sticky;
-        top: 0;
-        z-index: 10;
-        box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+        padding: 10px 14px;
+        border-bottom: 1px solid rgba(15, 23, 42, 0.08);
       }
-      .app-header h1 { margin: 0; font-size: 1.05rem; letter-spacing: 0.5px; text-transform: uppercase; }
-      .app-header .actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
-      .icon-btn { appearance: none; border: 1px solid var(--border); background: rgba(255,255,255,0.08); color: inherit; padding: 6px 10px; border-radius: 10px; font-size: 0.9rem; line-height: 1; display: inline-flex; align-items: center; gap: 8px; cursor: pointer; text-decoration: none; }
-      .icon-btn:hover { background: rgba(255,255,255,0.12); }
-      .icon { width: 16px; height: 16px; display: inline-block; }
-      .icon svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
-      .pill { font-size: .85rem; border: 1px solid var(--border); border-radius: 999px; padding: .25rem .65rem; background: var(--accent-soft); }
-      .pill.accent { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
-
-	      .tabs { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--border); background: rgba(255,255,255,0.02); position: sticky; top: 58px; z-index: 9; backdrop-filter: blur(8px); }
-      .tab-list { display: flex; gap: 6px; flex-wrap: wrap; }
-      .tab { padding: 6px 10px; border: 1px solid var(--border); border-radius: 999px; background: rgba(255,255,255,0.02); cursor: pointer; user-select: none; color: inherit; }
-      .tab.active { background: transparent; border-color: var(--accent); color: inherit; box-shadow: 0 0 0 2px rgba(47,124,246,0.22) inset; }
-      /* Inline rename input inside tabs */
-      .tab input.tab-rename { font: inherit; color: inherit; background: transparent; border: 0; outline: none; padding: 0; margin: 0; min-width: 60px; width: 12ch; }
-      .tabs .spacer { flex: 1; }
-	      .page { max-width: 1400px; margin: 0 auto; padding: 14px; }
-	      .container { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
-      .pane { height: 100%; border: 1px solid var(--border); border-radius: 14px; background: var(--pane-bg); overflow: hidden; box-shadow: var(--shadow); }
-      textarea { width: 100%; height: 100%; padding: 1rem; border: 0; outline: none; resize: none; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 14px; line-height: 1.5; background: transparent; color: inherit; }
-      #preview { overflow: auto; padding: 1rem; }
-      #preview h1, #preview h2, #preview h3 { border-bottom: 1px solid #eaecef; padding-bottom: .3rem; }
-      #preview pre { background: rgba(127,127,127,0.1); padding: .75rem; overflow: auto; border-radius: 6px; }
-      #preview code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-      #preview table { border-collapse: collapse; }
-      #preview table th, #preview table td { border: 1px solid #ddd; padding: .25rem .5rem; }
-      @media (max-width: 900px) { .container { grid-template-columns: 1fr; grid-auto-rows: 50vh 50vh; } }
+      [data-theme='dark'] .md-source-head { border-color: rgba(226, 237, 255, 0.1); }
+      .md-source-title {
+        margin: 0;
+        font-size: 0.86rem;
+        font-weight: 800;
+      }
+      textarea#input {
+        width: 100%;
+        min-height: 540px;
+        flex: 1;
+        resize: none;
+        border: 0;
+        outline: none;
+        padding: 18px;
+        background: transparent;
+        color: inherit;
+        font-family: var(--wt-font-mono);
+        font-size: 14px;
+        line-height: 1.55;
+      }
+      .md-preview-wrap {
+        min-width: 0;
+        overflow: auto;
+        border-top: 1px solid rgba(15, 23, 42, 0.08);
+      }
+      [data-theme='dark'] .md-preview-wrap { border-color: rgba(226, 237, 255, 0.1); }
+      .md-preview {
+        width: min(100%, var(--reader-width, 920px));
+        margin: 0 auto;
+        padding: 46px 36px 60px;
+        color: #192338;
+        font-family: var(--reader-font, var(--wt-font-sans));
+        font-size: var(--reader-font-size, 16px);
+        line-height: var(--reader-line-height, 1.58);
+      }
+      [data-theme='dark'] .md-preview { color: #e6edff; }
+      .md-preview > :first-child { margin-top: 0; }
+      .md-preview h1 {
+        margin: 0 0 20px;
+        color: #07112b;
+        font-size: clamp(2rem, 3vw, 3rem);
+        line-height: 1.08;
+        letter-spacing: 0;
+      }
+      .md-preview h2 {
+        margin-top: 32px;
+        padding-top: 22px;
+        border-top: 1px solid rgba(15, 23, 42, 0.12);
+        color: #0e172d;
+        font-size: 1.35rem;
+        line-height: 1.22;
+      }
+      .md-preview h3 {
+        margin-top: 22px;
+        color: #11182c;
+        font-size: 1.02rem;
+      }
+      [data-theme='dark'] .md-preview h1,
+      [data-theme='dark'] .md-preview h2,
+      [data-theme='dark'] .md-preview h3 { color: #f3f7ff; }
+      .md-preview p { margin: 0 0 16px; }
+      .md-preview a {
+        color: #2563eb;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 2px;
+      }
+      .md-preview blockquote {
+        margin: 18px 0;
+        padding: 2px 0 2px 16px;
+        border-left: 4px solid rgba(37, 99, 235, 0.32);
+        color: #475467;
+      }
+      .md-preview pre {
+        overflow: auto;
+        padding: 14px;
+        border: 1px solid rgba(15, 23, 42, 0.1);
+        border-radius: 8px;
+        background: rgba(15, 23, 42, 0.05);
+      }
+      .md-preview code {
+        font-family: var(--wt-font-mono);
+        font-size: 0.92em;
+      }
+      .md-preview :not(pre) > code {
+        padding: 0.12em 0.35em;
+        border-radius: 5px;
+        background: rgba(15, 23, 42, 0.07);
+      }
+      .md-preview table {
+        width: 100%;
+        margin: 22px 0;
+        border-collapse: separate;
+        border-spacing: 0;
+        overflow: hidden;
+        border: 1px solid rgba(15, 23, 42, 0.12);
+        border-radius: 8px;
+        font-size: 0.9em;
+      }
+      .md-preview th,
+      .md-preview td {
+        padding: 10px 12px;
+        border-right: 1px solid rgba(15, 23, 42, 0.1);
+        border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+        text-align: left;
+        vertical-align: top;
+      }
+      .md-preview th {
+        background: rgba(15, 23, 42, 0.04);
+        font-weight: 800;
+      }
+      .md-preview tr:last-child td { border-bottom: 0; }
+      .md-preview th:last-child,
+      .md-preview td:last-child { border-right: 0; }
+      .md-preview ul,
+      .md-preview ol { padding-left: 1.35em; }
+      .md-preview img {
+        max-width: 100%;
+        border-radius: 8px;
+      }
+      .md-reader.full .md-reader-grid {
+        display: block;
+      }
+      .md-reader.full .md-source-wrap {
+        display: none;
+      }
+      .md-reader.full .md-preview-wrap {
+        min-height: calc(100vh - 134px);
+      }
+      .md-reader.full .md-preview {
+        padding-top: 46px;
+      }
+      .md-menu-wrap {
+        position: relative;
+      }
+      .md-menu {
+        position: absolute;
+        top: calc(100% + 8px);
+        right: 0;
+        z-index: 20;
+        min-width: 180px;
+        display: none;
+        padding: 8px;
+        border: 1px solid rgba(15, 23, 42, 0.1);
+        border-radius: 8px;
+        background: #fff;
+        box-shadow: 0 18px 44px rgba(15, 23, 42, 0.16);
+      }
+      [data-theme='dark'] .md-menu {
+        border-color: rgba(226, 237, 255, 0.12);
+        background: #0f172a;
+      }
+      .md-menu.open { display: grid; gap: 4px; }
+      .md-menu button {
+        justify-content: flex-start;
+        width: 100%;
+        border: 0;
+        box-shadow: none;
+        background: transparent;
+      }
+      .md-hidden { display: none !important; }
+      .md-muted { color: #667085; }
+      @media (max-width: 1180px) {
+        .md-shell {
+          grid-template-columns: 360px minmax(0, 1fr);
+          gap: 14px;
+        }
+        .md-reader-grid {
+          grid-template-columns: 1fr;
+        }
+        .md-source-wrap {
+          border-right: 0;
+        }
+      }
+      @media (max-width: 860px) {
+        body[data-wt-tool='markdown'] .wt-header,
+        .md-shell {
+          width: min(calc(100% - 20px), 1880px);
+        }
+        .md-shell {
+          grid-template-columns: 1fr;
+        }
+        .md-sidebar {
+          order: 2;
+        }
+        .md-reader {
+          order: 1;
+        }
+        .md-reader-topbar {
+          padding-inline: 16px;
+          flex-wrap: wrap;
+        }
+        .md-reader-actions {
+          width: 100%;
+          justify-content: flex-end;
+        }
+        .md-preview {
+          padding: 30px 20px 44px;
+        }
+        textarea#input {
+          min-height: 420px;
+        }
+      }
+      @media print {
+        body[data-wt-tool='markdown'] .wt-header,
+        .md-sidebar,
+        .md-source-wrap,
+        .md-reader-topbar {
+          display: none !important;
+        }
+        .md-shell,
+        .md-reader,
+        .md-preview-wrap,
+        .md-preview {
+          display: block;
+          width: 100%;
+          margin: 0;
+          padding: 0;
+          border: 0;
+          box-shadow: none;
+        }
+      }
     </style>
-
     <script>
-      // MathJax v3 configuration
       window.MathJax = {
         tex: {
           inlineMath: [['$', '$']],
-          displayMath: [['$$','$$'], ['\\[', '\\]']]
+          displayMath: [['$$','$$'], ['\\[', '\\]']],
         },
-        options: { skipHtmlTags: ['script','noscript','style','textarea','pre','code'] }
+        options: { skipHtmlTags: ['script','noscript','style','textarea','pre','code'] },
       };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.7/dist/purify.min.js"></script>
-    <!-- Highlight.js theme (swapped dynamically for dark/light) -->
-    <link id="hljs-theme" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github.min.css">
-    <!-- Highlight.js full build (includes all languages) -->
+    <link id="hljs-theme" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github.min.css" />
     <script defer src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js"></script>
     <script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
   </head>
-	  <body class="wt" data-wt-tool="markdown" data-wt-title="Markdown Viewer">
-	    <div class="wt-header" role="banner"></div>
-	    <template id="wtHeaderExtra">
-	      <span id="modePill" class="pill">Checking…</span>
-	      <button id="copyHtml" class="wt-btn wt-btn-ghost" type="button" title="Copy rendered HTML">Copy HTML</button>
-	      <div id="authArea"></div>
-	    </template>
-	    <nav class="tabs">
-	      <div id="tabList" class="tab-list" role="tablist" aria-label="Markdown documents"></div>
-	      <div class="spacer"></div>
-	      <button id="newTab" class="wt-btn wt-btn-ghost" title="New document" type="button">+ New</button>
-	      <button id="renameTab" class="wt-btn wt-btn-ghost" title="Rename document" type="button">Rename</button>
-	      <button id="deleteTab" class="wt-btn wt-btn-danger" title="Delete document" type="button">Delete</button>
-	    </nav>
+  <body class="wt" data-wt-tool="markdown" data-wt-title="Markdown Viewer">
+    <div class="wt-header" role="banner"></div>
+    <template id="wtHeaderExtra">
+      <button id="helpButton" class="wt-btn" type="button" title="Markdown help" aria-label="Markdown help">?</button>
+      <button id="shareButton" class="wt-btn" type="button" title="Share Markdown" aria-label="Share Markdown">
+        <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7"/><path d="M12 16V4"/><path d="m7 9 5-5 5 5"/></svg>
+      </button>
+      <div id="authArea"></div>
+    </template>
 
-	    <div class="page wt-page">
-    <div class="container">
-      <section class="pane">
-        <textarea id="input" placeholder="Paste Markdown here..."># Welcome
+    <main class="md-shell">
+      <aside class="md-sidebar" aria-label="Markdown documents and settings">
+        <section class="md-card" aria-labelledby="documentsTitle">
+          <div class="md-card-head">
+            <h2 id="documentsTitle" class="md-card-title">Documents</h2>
+            <button id="newTab" class="md-text-btn primary" type="button" title="New document">
+              <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+              New
+            </button>
+          </div>
+          <div class="md-search-wrap">
+            <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m16 16 4 4"/></svg>
+            <input id="docSearch" class="md-field" type="search" placeholder="Search documents..." autocomplete="off" />
+            <span class="md-kbd">Ctrl K</span>
+          </div>
+          <div id="tabList" class="md-doc-list" role="tablist" aria-label="Markdown documents"></div>
+          <button id="showAllDocs" class="md-link-btn" type="button">
+            <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 3h8l4 4v14H8z"/><path d="M16 3v5h4"/><path d="M4 7v14h4"/></svg>
+            Show all documents
+          </button>
+        </section>
+
+        <section class="md-card" aria-labelledby="documentInfoTitle">
+          <h2 id="documentInfoTitle" class="md-card-title">Document Info</h2>
+          <dl class="md-info-grid">
+            <dt>Title</dt><dd id="infoTitle">Untitled</dd>
+            <dt>Source</dt><dd id="infoSource">Local only</dd>
+            <dt>Created</dt><dd id="infoCreated">-</dd>
+            <dt>Last updated</dt><dd id="infoUpdated">-</dd>
+            <dt>Size</dt><dd id="infoSize">0 B</dd>
+            <dt>Words</dt><dd id="infoWords">0</dd>
+            <dt>Reading time</dt><dd id="infoReadingTime">0 min</dd>
+          </dl>
+        </section>
+
+        <section class="md-card" aria-labelledby="viewTitle">
+          <h2 id="viewTitle" class="md-card-title">View</h2>
+          <div class="md-segment">
+            <button id="splitView" class="md-text-btn active" type="button" aria-pressed="true">
+              <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M12 4v16"/></svg>
+              Split View
+            </button>
+            <button id="fullView" class="md-text-btn" type="button" aria-pressed="false">
+              <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="2"/><path d="M9 4v16"/></svg>
+              Full Width
+            </button>
+          </div>
+        </section>
+
+        <section class="md-card" aria-labelledby="readingTitle">
+          <h2 id="readingTitle" class="md-card-title">Reading</h2>
+          <div class="md-setting-list">
+            <label>
+              <span>Font size</span>
+              <span class="md-stepper">
+                <button id="decreaseFont" type="button" title="Decrease font size">-</button>
+                <output id="fontSizeValue">16px</output>
+                <button id="increaseFont" type="button" title="Increase font size">+</button>
+              </span>
+            </label>
+            <label>
+              <span>Line height</span>
+              <select id="lineHeightSelect" class="md-select">
+                <option value="1.45">Compact</option>
+                <option value="1.58" selected>Comfortable</option>
+                <option value="1.75">Relaxed</option>
+              </select>
+            </label>
+            <label>
+              <span>Width</span>
+              <select id="widthSelect" class="md-select">
+                <option value="760px">Medium (760px)</option>
+                <option value="920px" selected>Wide (920px)</option>
+                <option value="1120px">Extra wide</option>
+              </select>
+            </label>
+            <label>
+              <span>Typography</span>
+              <select id="typeSelect" class="md-select">
+                <option value="system" selected>System</option>
+                <option value="serif">Serif</option>
+                <option value="mono">Mono</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
+        <section class="md-card" aria-labelledby="exportTitle">
+          <h2 id="exportTitle" class="md-card-title">Export &amp; Share</h2>
+          <div class="md-export-grid">
+            <button id="exportHtml" class="md-text-btn" type="button">
+              <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m8 9-4 3 4 3"/><path d="m16 9 4 3-4 3"/><path d="m14 4-4 16"/></svg>
+              Export as HTML
+            </button>
+            <button id="exportPdf" class="md-text-btn" type="button">
+              <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M9 15h6"/></svg>
+              Export as PDF
+            </button>
+            <button id="copyHtml" class="md-text-btn wide" type="button">
+              <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><rect x="2" y="2" width="13" height="13" rx="2"/></svg>
+              Copy HTML
+            </button>
+          </div>
+        </section>
+      </aside>
+
+      <section id="reader" class="md-reader" aria-label="Markdown reader and raw editor">
+        <div class="md-reader-topbar">
+          <div class="md-meta-line">
+            <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4"/><path d="M8 2v4"/><path d="M3 10h18"/></svg>
+            <span id="readerMeta">Untitled</span>
+          </div>
+          <div class="md-reader-actions">
+            <span id="saveState" class="md-save-state">
+              <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+              Auto-saved
+            </span>
+            <button id="bookmarkButton" class="md-icon-btn" type="button" title="Bookmark document" aria-label="Bookmark document">
+              <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 21 12 17 5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+            <button id="printButton" class="md-icon-btn" type="button" title="Print document" aria-label="Print document">
+              <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9V2h12v7"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><path d="M6 14h12v8H6z"/></svg>
+            </button>
+            <span class="md-menu-wrap">
+              <button id="moreButton" class="md-icon-btn" type="button" title="More actions" aria-label="More actions" aria-expanded="false">
+                <svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+              </button>
+              <span id="moreMenu" class="md-menu" role="menu">
+                <button id="renameTab" class="md-text-btn" type="button" role="menuitem">Rename document</button>
+                <button id="deleteTab" class="md-text-btn danger" type="button" role="menuitem">Delete document</button>
+              </span>
+            </span>
+          </div>
+        </div>
+        <div class="md-reader-grid">
+          <section class="md-source-wrap" aria-label="Raw Markdown editor">
+            <div class="md-source-head">
+              <h2 class="md-source-title">Raw Markdown</h2>
+              <span id="sourceHint" class="md-muted">Editable scan</span>
+            </div>
+            <textarea id="input" spellcheck="false" placeholder="Paste Markdown here..."># Welcome
 
 Type Markdown on the left and see HTML on the right.
 
@@ -108,451 +842,706 @@ hello('world')
 Block math:
 
 $$
-\int_{-\infty}^{\infty} e^{-x^2} \\mathrm{d}x = \sqrt{\pi}
+\int_{-\infty}^{\infty} e^{-x^2} \mathrm{d}x = \sqrt{\pi}
 $$
-
-        </textarea>
+</textarea>
+          </section>
+          <section class="md-preview-wrap" aria-label="Rendered Markdown preview">
+            <article id="preview" class="md-preview"></article>
+          </section>
+        </div>
       </section>
-      <section id="preview" class="pane"></section>
-    </div>
-    </div>
-    
+    </main>
 
-	    <script>
-	      (function() {
-	        function boot() {
-	        const TOOL = 'markdown';
-	        const LOCAL_STORAGE_KEY = 'md_docs_v1';
-	        const LOCAL_ACTIVE_KEY = 'md_active_v1';
-	        const REMOTE_ACTIVE_KEY = 'md_active_remote_v1';
-	        const root = document.documentElement;
-	
-	        function syncHighlightTheme(theme) {
-	          const link = document.getElementById('hljs-theme');
-	          if (link && link.tagName === 'LINK') {
-	            const base = 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/';
-	            link.setAttribute('href', theme === 'dark' ? base + 'github-dark-dimmed.min.css' : base + 'github.min.css');
-	          }
-	        }
-	        syncHighlightTheme(root.getAttribute('data-theme') || 'light');
-	        window.addEventListener('wt-theme-change', (ev) => syncHighlightTheme(ev.detail?.theme || 'light'));
+    <script>
+      (function() {
+        function boot() {
+          const TOOL = 'markdown';
+          const LOCAL_STORAGE_KEY = 'md_docs_v1';
+          const LOCAL_ACTIVE_KEY = 'md_active_v1';
+          const REMOTE_ACTIVE_KEY = 'md_active_remote_v1';
+          const READER_SETTINGS_KEY = 'md_reader_settings_v1';
+          const DEFAULT_CONTENT = `# Welcome\n\nType Markdown on the left and see HTML on the right.\n\n- Supports GitHub-flavored Markdown\n- Sanitizes output with DOMPurify\n- Renders LaTeX via MathJax: $E=mc^2$\n\nBlock math:\n\n$$\n\\int_{-\\infty}^{\\infty} e^{-x^2} \\mathrm{d}x = \\sqrt{\\pi}\n$$\n`;
+          const root = document.documentElement;
 
-        const input = document.getElementById('input');
-        const preview = document.getElementById('preview');
-        const tabList = document.getElementById('tabList');
-        const newBtn = document.getElementById('newTab');
-        const renameBtn = document.getElementById('renameTab');
-        const deleteBtn = document.getElementById('deleteTab');
-        const authArea = document.getElementById('authArea');
-        const modePill = document.getElementById('modePill');
-        if (!input || !preview) return;
-
-        // Map common aliases to highlight.js language IDs
-        function normalizeLang(lang) {
-          if (!lang) return '';
-          let id = String(lang).trim().toLowerCase();
-          id = id.replace(/^language-/, '').replace(/[^a-z0-9+#-]+/g, '');
-          const map = {
-            js: 'javascript', mjs: 'javascript', cjs: 'javascript', node: 'javascript',
-            ts: 'typescript', tsx: 'typescript', jsx: 'javascript',
-            cplusplus: 'cpp', 'c++': 'cpp', cpp: 'cpp',
-            csharp: 'csharp', 'c#': 'csharp', cs: 'csharp',
-            sh: 'bash', zsh: 'bash', shell: 'bash', console: 'bash',
-            ps1: 'powershell', pwsh: 'powershell',
-            py: 'python',
-            rb: 'ruby',
-            tf: 'hcl', terraform: 'hcl',
-            yml: 'yaml'
-          };
-          return map[id] || id;
-        }
-
-        // Configure marked for GFM and line breaks
-        if (window.marked && typeof window.marked.setOptions === 'function') {
-          window.marked.setOptions({ gfm: true, breaks: true });
-        }
-
-        async function api(path, opts={}) {
-          const res = await fetch(path, Object.assign({ credentials: 'include' }, opts));
-          if (!res.ok) throw new Error(await res.text());
-          return res.json();
-        }
-
-        const DEFAULT_CONTENT = `# Welcome\n\nType Markdown on the left and see HTML on the right.\n\n- Supports GitHub-flavored Markdown\n- Sanitizes output with DOMPurify\n- Renders LaTeX via MathJax: $E=mc^2$\n\nBlock math:\n\n$$\n\\int_{-\\infty}^{\\infty} e^{-x^2} \\mathrm{d}x = \\sqrt{\\pi}\n$$\n`;
-
-        // --- Storage mode (local for guests; account (D1) for signed-in users) ---
-        let AUTH = { loggedIn: false, user: null };
-        let MODE = 'local'; // 'local' | 'account'
-
-        let docs = [];
-        let active = '';
-
-        function uid() { return 'd_' + Math.random().toString(36).slice(2, 9); }
-
-        function loadLocalState() {
-          let d = [];
-          try { d = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || '[]'); } catch {}
-          let a = localStorage.getItem(LOCAL_ACTIVE_KEY) || (d[0]?.id ?? '');
-          return { docs: d, active: a };
-        }
-        function saveLocalState(d, a) {
-          localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(d));
-          if (a) localStorage.setItem(LOCAL_ACTIVE_KEY, a);
-        }
-
-        function setModePill() {
-          if (!modePill) return;
-          if (MODE === 'account') {
-            modePill.textContent = 'Account storage';
-            modePill.classList.add('accent');
-          } else {
-            modePill.textContent = 'Local only';
-            modePill.classList.remove('accent');
+          function $(id) {
+            return document.getElementById(id);
           }
-        }
 
-        async function refreshAuth() {
-          try {
-            const me = await api('/api/auth/me');
-            AUTH = { loggedIn: !!me.loggedIn, user: me.user || null };
-          } catch {
-            AUTH = { loggedIn: false, user: null };
-          }
-          MODE = AUTH.loggedIn ? 'account' : 'local';
-          setModePill();
-          renderAuth();
-        }
+          const input = $('input');
+          const preview = $('preview');
+          const tabList = $('tabList');
+          const newBtn = $('newTab');
+          const renameBtn = $('renameTab');
+          const deleteBtn = $('deleteTab');
+          const copyBtn = $('copyHtml');
+          const authArea = $('authArea');
+          const reader = $('reader');
+          const splitView = $('splitView');
+          const fullView = $('fullView');
+          const saveState = $('saveState');
+          const docSearch = $('docSearch');
+          const showAllDocs = $('showAllDocs');
+          const moreButton = $('moreButton');
+          const moreMenu = $('moreMenu');
+          const exportHtmlBtn = $('exportHtml');
+          const exportPdfBtn = $('exportPdf');
+          const printButton = $('printButton');
+          const bookmarkButton = $('bookmarkButton');
+          const shareButton = $('shareButton');
+          const helpButton = $('helpButton');
+          const fontSizeValue = $('fontSizeValue');
+          const decreaseFont = $('decreaseFont');
+          const increaseFont = $('increaseFont');
+          const lineHeightSelect = $('lineHeightSelect');
+          const widthSelect = $('widthSelect');
+          const typeSelect = $('typeSelect');
+          if (!input || !preview) return;
 
-	        function renderAuth() {
-	          if (!authArea) return;
-	          authArea.innerHTML = '';
-	          if (!AUTH.loggedIn) {
-	            const next = encodeURIComponent(location.pathname + location.search);
-	            const a = document.createElement('a');
-	            a.className = 'wt-btn wt-btn-primary';
-	            a.href = `/auth/google/login?returnTo=${next}`;
-	            a.textContent = 'Sign in';
-	            authArea.appendChild(a);
-	            return;
-	          }
-          const u = AUTH.user || {};
-          const span = document.createElement('span');
-          span.style.fontSize = '0.9rem';
-          span.style.opacity = '0.9';
-          span.textContent = (u.email || u.name || 'Signed in');
-	          const btn = document.createElement('button');
-	          btn.className = 'wt-btn wt-btn-ghost';
-	          btn.type = 'button';
-	          btn.textContent = 'Sign out';
-	          btn.addEventListener('click', async () => {
-	            try { await api('/api/auth/logout', { method: 'POST' }); } catch {}
-	            location.reload();
-	          });
-          authArea.appendChild(span);
-          authArea.appendChild(btn);
-        }
-
-        function getActive() { return docs.find(d => d.id === active) || docs[0]; }
-
-        function startInlineRename(docId) {
-          if (!tabList) return;
-          const doc = docs.find(d => d.id === docId);
-          const btn = tabList.querySelector(`button.tab[data-id="${docId}"]`);
-          if (!doc || !btn) return;
-          if (btn.querySelector('input.tab-rename')) return;
-          const original = doc.title || 'Untitled';
-          const inputEl = document.createElement('input');
-          inputEl.type = 'text';
-          inputEl.className = 'tab-rename';
-          inputEl.value = original;
-          btn.textContent = '';
-          btn.appendChild(inputEl);
-          btn.disabled = true;
-          inputEl.focus();
-          inputEl.select();
-          const finish = (commit) => {
-            if (!btn.disabled) return;
-            btn.disabled = false;
-            inputEl.blur();
-            const val = (commit ? inputEl.value : original).trim();
-            if (commit) {
-              doc.title = val || original;
-              persistRename(doc).catch(() => {});
+          function syncHighlightTheme(theme) {
+            const link = $('hljs-theme');
+            if (link && link.tagName === 'LINK') {
+              const base = 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/';
+              link.setAttribute('href', theme === 'dark' ? base + 'github-dark-dimmed.min.css' : base + 'github.min.css');
             }
-            renderTabs();
-            const newBtnRef = tabList.querySelector(`button.tab[data-id="${docId}"]`);
-            if (newBtnRef) newBtnRef.focus();
-          };
-          inputEl.addEventListener('keydown', (e) => {
-            e.stopPropagation();
-            if (e.key === 'Enter') {
-              e.preventDefault();
-              finish(true);
-            } else if (e.key === 'Escape') {
-              e.preventDefault();
-              finish(false);
-            }
-          });
-          inputEl.addEventListener('blur', () => finish(true), { once: true });
-        }
-
-        function renderTabs() {
-          if (!tabList) return;
-          tabList.innerHTML = '';
-          docs.forEach(doc => {
-            const b = document.createElement('button');
-            b.className = 'tab' + (doc.id === active ? ' active' : '');
-            b.textContent = doc.title || 'Untitled';
-            b.dataset.id = doc.id;
-            b.setAttribute('role', 'tab');
-            b.setAttribute('aria-selected', String(doc.id === active));
-            b.addEventListener('click', () => {
-              switchToDoc(doc.id).catch(() => {});
-            });
-            b.addEventListener('dblclick', (e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (active !== doc.id) return switchToDoc(doc.id).then(() => setTimeout(() => startInlineRename(doc.id), 0));
-              setTimeout(() => startInlineRename(doc.id), 0);
-            });
-            tabList.appendChild(b);
-          });
-        }
-
-        async function newDoc() {
-          if (MODE === 'account') {
-            const count = docs.length + 1;
-            const res = await api('/api/pages/create', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ tool: TOOL, title: `Doc ${count}`, content: '' }),
-            });
-            docs.unshift({ id: res.id, title: `Doc ${count}`, content: '' });
-            active = res.id;
-            localStorage.setItem(REMOTE_ACTIVE_KEY, active);
-            input.value = '';
-            renderTabs();
-            render();
-            return;
           }
-          const count = docs.length + 1;
-          const doc = { id: uid(), title: `Doc ${count}`, content: '' };
-          const current = getActive();
-          if (current) current.content = input.value;
-          docs.push(doc);
-          active = doc.id;
-          saveLocalState(docs, active);
-          input.value = '';
-          render();
-          renderTabs();
-        }
+          syncHighlightTheme(root.getAttribute('data-theme') || 'light');
+          window.addEventListener('wt-theme-change', (ev) => syncHighlightTheme(ev.detail?.theme || 'light'));
 
-        function renameDoc() {
-          const current = getActive();
-          if (!current) return;
-          renderTabs();
-          startInlineRename(current.id);
-        }
+          if (window.marked && typeof window.marked.setOptions === 'function') {
+            window.marked.setOptions({ gfm: true, breaks: true });
+          }
 
-        async function deleteDoc() {
-          if (docs.length <= 1) { alert('At least one document must remain.'); return; }
-          const current = getActive();
-          if (!current) return;
-          const idx = docs.findIndex(d => d.id === current.id);
-          if (idx < 0) return;
-          if (MODE === 'account') {
-            await api('/api/pages/delete', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ id: current.id }),
+          async function api(path, opts = {}) {
+            const res = await fetch(path, Object.assign({ credentials: 'include' }, opts));
+            if (!res.ok) throw new Error(await res.text());
+            return res.json();
+          }
+
+          let AUTH = { loggedIn: false, user: null };
+          let MODE = 'local';
+          let docs = [];
+          let active = '';
+          let searchText = '';
+          let saveTimer;
+          let readerSettings = loadReaderSettings();
+
+          function uid() {
+            return 'd_' + Math.random().toString(36).slice(2, 9);
+          }
+
+          function nowIso() {
+            return new Date().toISOString();
+          }
+
+          function normalizeDoc(doc, index) {
+            const created = doc.created_at || doc.createdAt || nowIso();
+            const updated = doc.updated_at || doc.updatedAt || created;
+            return {
+              id: String(doc.id || uid()),
+              title: String(doc.title || `Doc ${index + 1}`),
+              content: doc.content === null ? null : (typeof doc.content === 'string' ? doc.content : doc.content ?? ''),
+              created_at: created,
+              updated_at: updated,
+              bookmarked: !!doc.bookmarked,
+            };
+          }
+
+          function loadLocalState() {
+            let d = [];
+            try { d = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || '[]'); } catch {}
+            d = Array.isArray(d) ? d.map(normalizeDoc) : [];
+            const a = localStorage.getItem(LOCAL_ACTIVE_KEY) || (d[0]?.id ?? '');
+            return { docs: d, active: a };
+          }
+
+          function saveLocalState(d, a) {
+            localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(d));
+            if (a) localStorage.setItem(LOCAL_ACTIVE_KEY, a);
+          }
+
+          function loadReaderSettings() {
+            const defaults = { fontSize: 16, lineHeight: '1.58', width: '920px', type: 'system', view: 'split' };
+            try {
+              const saved = JSON.parse(localStorage.getItem(READER_SETTINGS_KEY) || '{}');
+              return Object.assign(defaults, saved || {});
+            } catch {
+              return defaults;
+            }
+          }
+
+          function saveReaderSettings() {
+            localStorage.setItem(READER_SETTINGS_KEY, JSON.stringify(readerSettings));
+          }
+
+          function applyReaderSettings() {
+            const fontSize = Math.min(22, Math.max(12, Number(readerSettings.fontSize) || 16));
+            readerSettings.fontSize = fontSize;
+            preview.style.setProperty('--reader-font-size', `${fontSize}px`);
+            preview.style.setProperty('--reader-line-height', readerSettings.lineHeight || '1.58');
+            preview.style.setProperty('--reader-width', readerSettings.width || '920px');
+            const fontMap = {
+              system: 'var(--wt-font-sans)',
+              serif: 'var(--wt-font-serif)',
+              mono: 'var(--wt-font-mono)',
+            };
+            preview.style.setProperty('--reader-font', fontMap[readerSettings.type] || fontMap.system);
+            if (fontSizeValue) fontSizeValue.textContent = `${fontSize}px`;
+            if (lineHeightSelect) lineHeightSelect.value = readerSettings.lineHeight || '1.58';
+            if (widthSelect) widthSelect.value = readerSettings.width || '920px';
+            if (typeSelect) typeSelect.value = readerSettings.type || 'system';
+            setView(readerSettings.view === 'full' ? 'full' : 'split', false);
+          }
+
+          function setView(view, persist = true) {
+            readerSettings.view = view;
+            reader?.classList.toggle('full', view === 'full');
+            splitView?.classList.toggle('active', view !== 'full');
+            fullView?.classList.toggle('active', view === 'full');
+            splitView?.setAttribute('aria-pressed', String(view !== 'full'));
+            fullView?.setAttribute('aria-pressed', String(view === 'full'));
+            if (persist) saveReaderSettings();
+          }
+
+          function getActive() {
+            return docs.find(d => d.id === active) || docs[0];
+          }
+
+          function formatDate(value) {
+            if (!value) return '-';
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) return '-';
+            return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+          }
+
+          function formatRange(doc) {
+            if (!doc) return 'No document selected';
+            const dates = [doc.created_at, doc.updated_at].filter(Boolean).map(v => new Date(v));
+            if (!dates.length || dates.some(d => Number.isNaN(d.getTime()))) return doc.title || 'Untitled';
+            return `${doc.title || 'Untitled'}, ${formatDate(dates[0])} to ${formatDate(dates[dates.length - 1])}`;
+          }
+
+          function byteSize(text) {
+            return new Blob([text || '']).size;
+          }
+
+          function formatBytes(bytes) {
+            if (bytes < 1024) return `${bytes} B`;
+            if (bytes < 1024 * 1024) return `~${Math.round(bytes / 1024)} KB`;
+            return `~${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+          }
+
+          function wordCount(text) {
+            const words = String(text || '').trim().match(/\b[\w'-]+\b/g);
+            return words ? words.length : 0;
+          }
+
+          function readingMinutes(words) {
+            return Math.max(1, Math.ceil(words / 240));
+          }
+
+          function excerpt(text) {
+            const first = String(text || '')
+              .replace(/^#+\s+/gm, '')
+              .split('\n')
+              .map(line => line.trim())
+              .filter(Boolean)[0] || 'Raw Markdown document';
+            return first.slice(0, 74);
+          }
+
+          function setSaveState(label, saving = false) {
+            if (!saveState) return;
+            saveState.lastChild.textContent = ` ${label}`;
+            saveState.style.color = saving ? '#b45309' : '#0f766e';
+          }
+
+          async function refreshAuth() {
+            try {
+              const me = await api('/api/auth/me');
+              AUTH = { loggedIn: !!me.loggedIn, user: me.user || null };
+            } catch {
+              AUTH = { loggedIn: false, user: null };
+            }
+            MODE = AUTH.loggedIn ? 'account' : 'local';
+            renderAuth();
+          }
+
+          function renderAuth() {
+            if (!authArea) return;
+            authArea.innerHTML = '';
+            if (!AUTH.loggedIn) {
+              const next = encodeURIComponent(location.pathname + location.search);
+              const a = document.createElement('a');
+              a.className = 'wt-btn wt-btn-primary';
+              a.href = `/auth/google/login?returnTo=${next}`;
+              a.textContent = 'Sign in';
+              authArea.appendChild(a);
+              return;
+            }
+            const u = AUTH.user || {};
+            const span = document.createElement('span');
+            span.textContent = u.email || u.name || 'Signed in';
+            const btn = document.createElement('button');
+            btn.className = 'wt-btn wt-btn-ghost';
+            btn.type = 'button';
+            btn.textContent = 'Sign out';
+            btn.addEventListener('click', async () => {
+              try { await api('/api/auth/logout', { method: 'POST' }); } catch {}
+              location.reload();
             });
-            docs.splice(idx, 1);
-            active = docs[Math.max(0, idx - 1)].id;
+            authArea.appendChild(span);
+            authArea.appendChild(btn);
+          }
+
+          function renderDocuments() {
+            if (!tabList) return;
+            tabList.innerHTML = '';
+            const query = searchText.trim().toLowerCase();
+            const filtered = docs.filter(doc => {
+              if (!query) return true;
+              return `${doc.title || ''}\n${doc.content || ''}`.toLowerCase().includes(query);
+            });
+            filtered.forEach(doc => {
+              const button = document.createElement('button');
+              button.className = 'md-doc-item' + (doc.id === active ? ' active' : '');
+              button.dataset.id = doc.id;
+              button.type = 'button';
+              button.setAttribute('role', 'tab');
+              button.setAttribute('aria-selected', String(doc.id === active));
+              button.innerHTML = [
+                '<span class="md-doc-icon"><svg class="md-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M9 13h6"/><path d="M9 17h4"/></svg></span>',
+                `<span><span class="md-doc-title">${escapeHtml(doc.title || 'Untitled')}</span><span class="md-doc-subtitle">${escapeHtml(excerpt(doc.content || ''))}</span></span>`,
+                '<span class="md-more-dots">...</span>',
+              ].join('');
+              button.addEventListener('click', () => {
+                switchToDoc(doc.id).catch(() => {});
+              });
+              button.addEventListener('dblclick', (e) => {
+                e.preventDefault();
+                if (active !== doc.id) {
+                  switchToDoc(doc.id).then(renameDoc).catch(() => {});
+                } else {
+                  renameDoc();
+                }
+              });
+              tabList.appendChild(button);
+            });
+            if (!filtered.length) {
+              const empty = document.createElement('div');
+              empty.className = 'md-muted';
+              empty.textContent = 'No documents match this search.';
+              tabList.appendChild(empty);
+            }
+          }
+
+          function renderInfo() {
+            const doc = getActive();
+            const content = input.value || '';
+            const words = wordCount(content);
+            $('infoTitle').textContent = doc?.title || 'Untitled';
+            $('infoSource').textContent = MODE === 'account' ? 'Account storage' : 'Local only';
+            $('infoCreated').textContent = formatDate(doc?.created_at);
+            $('infoUpdated').textContent = formatDate(doc?.updated_at);
+            $('infoSize').textContent = formatBytes(byteSize(content));
+            $('infoWords').textContent = words.toLocaleString();
+            $('infoReadingTime').textContent = `~${readingMinutes(words)} min`;
+            $('readerMeta').textContent = formatRange(doc);
+            bookmarkButton?.classList.toggle('active', !!doc?.bookmarked);
+          }
+
+          function escapeHtml(s) {
+            return String(s)
+              .replaceAll('&', '&amp;')
+              .replaceAll('<', '&lt;')
+              .replaceAll('>', '&gt;')
+              .replaceAll('"', '&quot;')
+              .replaceAll("'", '&#039;');
+          }
+
+          function normalizeLang(lang) {
+            if (!lang) return '';
+            let id = String(lang).trim().toLowerCase();
+            id = id.replace(/^language-/, '').replace(/[^a-z0-9+#-]+/g, '');
+            const map = {
+              js: 'javascript', mjs: 'javascript', cjs: 'javascript', node: 'javascript',
+              ts: 'typescript', tsx: 'typescript', jsx: 'javascript',
+              cplusplus: 'cpp', 'c++': 'cpp', cpp: 'cpp',
+              csharp: 'csharp', 'c#': 'csharp', cs: 'csharp',
+              sh: 'bash', zsh: 'bash', shell: 'bash', console: 'bash',
+              ps1: 'powershell', pwsh: 'powershell',
+              py: 'python',
+              rb: 'ruby',
+              tf: 'hcl', terraform: 'hcl',
+              yml: 'yaml',
+            };
+            return map[id] || id;
+          }
+
+          function render() {
+            const md = input.value || '';
+            let raw = md;
+            const mk = window.marked;
+            if (mk) {
+              if (typeof mk.parse === 'function') raw = mk.parse(md);
+              else if (typeof mk === 'function') raw = mk(md);
+            }
+            const safe = window.DOMPurify ? window.DOMPurify.sanitize(raw) : raw;
+            preview.innerHTML = safe;
+            if (window.hljs) {
+              preview.querySelectorAll('pre code').forEach((el) => {
+                try {
+                  let given = '';
+                  for (const c of el.classList) {
+                    if (c.startsWith('language-')) {
+                      given = c.slice(9);
+                      break;
+                    }
+                  }
+                  const norm = normalizeLang(given);
+                  Array.from(el.classList).filter(c => c.startsWith('language-')).forEach(c => el.classList.remove(c));
+                  if (norm && window.hljs.getLanguage(norm)) el.classList.add('language-' + norm);
+                  el.classList.add('hljs');
+                  window.hljs.highlightElement(el);
+                } catch {}
+              });
+            }
+            if (window.MathJax && window.MathJax.typesetPromise) {
+              window.MathJax.typesetPromise([preview]).catch(() => {});
+            }
+            renderInfo();
+          }
+
+          async function loadAccountDocs() {
+            const list = await api(`/api/pages/list?tool=${encodeURIComponent(TOOL)}`);
+            docs = (list || []).map((r, index) => ({
+              id: r.id,
+              title: r.title,
+              content: null,
+              created_at: r.created_at || nowIso(),
+              updated_at: r.updated_at || r.created_at || nowIso(),
+              bookmarked: false,
+            })).map(normalizeDoc);
+            if (!docs.length) {
+              const created = await api('/api/pages/create', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ tool: TOOL, title: 'Welcome', content: input.value || DEFAULT_CONTENT }),
+              });
+              docs = [normalizeDoc({ id: created.id, title: 'Welcome', content: input.value || DEFAULT_CONTENT }, 0)];
+              active = created.id;
+              localStorage.setItem(REMOTE_ACTIVE_KEY, active);
+              return;
+            }
+            const wanted = localStorage.getItem(REMOTE_ACTIVE_KEY) || '';
+            active = docs.some(d => d.id === wanted) ? wanted : docs[0].id;
             localStorage.setItem(REMOTE_ACTIVE_KEY, active);
             await ensureLoaded(active);
             input.value = getActive().content || '';
-            render();
-            renderTabs();
-            return;
           }
-          docs.splice(idx, 1);
-          active = docs[Math.max(0, idx - 1)].id;
-          saveLocalState(docs, active);
-          input.value = getActive().content || '';
-          render();
-          renderTabs();
-        }
 
-        if (newBtn) newBtn.addEventListener('click', newDoc);
-        if (renameBtn) renameBtn.addEventListener('click', renameDoc);
-        if (deleteBtn) deleteBtn.addEventListener('click', deleteDoc);
-
-        async function loadAccountDocs() {
-          const list = await api(`/api/pages/list?tool=${encodeURIComponent(TOOL)}`);
-          docs = (list || []).map(r => ({ id: r.id, title: r.title, content: null }));
-          if (!docs.length) {
-            const created = await api('/api/pages/create', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ tool: TOOL, title: 'Welcome', content: input.value || DEFAULT_CONTENT }),
-            });
-            docs = [{ id: created.id, title: 'Welcome', content: input.value || DEFAULT_CONTENT }];
-            active = created.id;
-            localStorage.setItem(REMOTE_ACTIVE_KEY, active);
-            return;
+          function loadLocalDocs() {
+            const st = loadLocalState();
+            docs = st.docs;
+            active = st.active;
+            if (!Array.isArray(docs) || docs.length === 0) {
+              docs = [normalizeDoc({ id: uid(), title: 'Welcome', content: input.value || DEFAULT_CONTENT }, 0)];
+              active = docs[0].id;
+              saveLocalState(docs, active);
+            }
+            const current = getActive();
+            active = current.id;
+            input.value = current.content || '';
           }
-          const wanted = localStorage.getItem(REMOTE_ACTIVE_KEY) || '';
-          active = docs.some(d => d.id === wanted) ? wanted : docs[0].id;
-          localStorage.setItem(REMOTE_ACTIVE_KEY, active);
-          await ensureLoaded(active);
-          input.value = getActive().content || '';
-        }
 
-        function loadLocalDocs() {
-          let st = loadLocalState();
-          docs = st.docs;
-          active = st.active;
-          if (!Array.isArray(docs) || docs.length === 0) {
-            docs = [{ id: uid(), title: 'Welcome', content: input.value || DEFAULT_CONTENT }];
-            active = docs[0].id;
-            saveLocalState(docs, active);
+          async function ensureLoaded(docId) {
+            const doc = docs.find(d => d.id === docId);
+            if (!doc || MODE !== 'account' || typeof doc.content === 'string') return;
+            const full = await api(`/api/pages/get?id=${encodeURIComponent(docId)}`);
+            doc.title = full.title || doc.title;
+            doc.content = full.content || '';
+            doc.created_at = full.created_at || doc.created_at;
+            doc.updated_at = full.updated_at || doc.updated_at;
           }
-          input.value = getActive().content || '';
-        }
 
-        async function ensureLoaded(docId) {
-          const doc = docs.find(d => d.id === docId);
-          if (!doc) return;
-          if (MODE !== 'account') return;
-          if (typeof doc.content === 'string') return;
-          const full = await api(`/api/pages/get?id=${encodeURIComponent(docId)}`);
-          doc.title = full.title || doc.title;
-          doc.content = full.content || '';
-        }
-
-        async function switchToDoc(docId) {
-          const current = getActive();
-          if (current) {
+          async function persistCurrent() {
+            const current = getActive();
+            if (!current) return;
             current.content = input.value;
+            current.updated_at = nowIso();
+            setSaveState('Saving...', true);
             if (MODE === 'account') {
-              api('/api/pages/update', {
+              await api('/api/pages/update', {
                 method: 'POST',
                 headers: { 'content-type': 'application/json' },
                 body: JSON.stringify({ id: current.id, content: current.content }),
-              }).catch(() => {});
+              });
             } else {
               saveLocalState(docs, active);
             }
+            setSaveState('Auto-saved', false);
+            renderDocuments();
+            renderInfo();
           }
-          active = docId;
-          if (MODE === 'account') localStorage.setItem(REMOTE_ACTIVE_KEY, active);
-          await ensureLoaded(active);
-          input.value = getActive().content || '';
-          render();
-          renderTabs();
-        }
 
-        async function persistRename(doc) {
-          if (MODE === 'account') {
-            await api('/api/pages/update', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ id: doc.id, title: doc.title }),
-            });
-            return;
-          }
-          saveLocalState(docs, active);
-        }
-
-        const render = () => {
-          const md = input.value || '';
-          let raw = md;
-          const mk = window.marked;
-          if (mk) {
-            if (typeof mk.parse === 'function') raw = mk.parse(md);
-            else if (typeof mk === 'function') raw = mk(md);
-          }
-          const safe = window.DOMPurify ? window.DOMPurify.sanitize(raw) : raw;
-          preview.innerHTML = safe;
-
-          // Highlight any code blocks (prefer declared language; if unknown, auto-detect)
-          if (window.hljs) {
-            preview.querySelectorAll('pre code').forEach((el) => {
-              try {
-                // Normalize language if present
-                let given = '';
-                for (const c of el.classList) { if (c.startsWith('language-')) { given = c.slice(9); break; } }
-                const norm = normalizeLang(given);
-                // Remove all language-* so we can add the normalized one or let auto-detect work
-                Array.from(el.classList).filter(c => c.startsWith('language-')).forEach(c => el.classList.remove(c));
-                if (norm && window.hljs.getLanguage(norm)) {
-                  el.classList.add('language-' + norm);
-                }
-                el.classList.add('hljs');
-                window.hljs.highlightElement(el);
-              } catch {}
-            });
-          }
-          if (window.MathJax && window.MathJax.typesetPromise) {
-            window.MathJax.typesetPromise([preview]).catch(() => {});
-          }
-        };
-
-        let t;
-        input.addEventListener('input', () => {
-          render();
-          clearTimeout(t);
-          t = setTimeout(() => {
+          async function switchToDoc(docId) {
             const current = getActive();
             if (current) {
               current.content = input.value;
-              if (MODE === 'account') {
+              if (MODE === 'local') saveLocalState(docs, active);
+              else {
                 api('/api/pages/update', {
                   method: 'POST',
                   headers: { 'content-type': 'application/json' },
                   body: JSON.stringify({ id: current.id, content: current.content }),
                 }).catch(() => {});
-              } else {
-                saveLocalState(docs, active);
               }
             }
-          }, 450);
-        });
-        const copyBtn = document.getElementById('copyHtml');
-        if (copyBtn) {
-          copyBtn.addEventListener('click', async () => {
+            active = docId;
+            if (MODE === 'account') localStorage.setItem(REMOTE_ACTIVE_KEY, active);
+            await ensureLoaded(active);
+            input.value = getActive().content || '';
+            closeMoreMenu();
+            render();
+            renderDocuments();
+            setSaveState('Auto-saved', false);
+          }
+
+          async function newDoc() {
+            await persistCurrent().catch(() => {});
+            const count = docs.length + 1;
+            const title = `Doc ${count}`;
+            if (MODE === 'account') {
+              const res = await api('/api/pages/create', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ tool: TOOL, title, content: '' }),
+              });
+              docs.unshift(normalizeDoc({ id: res.id, title, content: '' }, 0));
+              active = res.id;
+              localStorage.setItem(REMOTE_ACTIVE_KEY, active);
+            } else {
+              const doc = normalizeDoc({ id: uid(), title, content: '' }, count - 1);
+              docs.push(doc);
+              active = doc.id;
+              saveLocalState(docs, active);
+            }
+            input.value = '';
+            render();
+            renderDocuments();
+            input.focus();
+          }
+
+          async function persistRename(doc) {
+            if (MODE === 'account') {
+              await api('/api/pages/update', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ id: doc.id, title: doc.title }),
+              });
+            } else {
+              saveLocalState(docs, active);
+            }
+          }
+
+          function renameDoc() {
+            const current = getActive();
+            if (!current) return;
+            const next = prompt('Rename document', current.title || 'Untitled');
+            if (next === null) return;
+            const title = next.trim() || current.title || 'Untitled';
+            current.title = title.slice(0, 200);
+            current.updated_at = nowIso();
+            persistRename(current).catch(() => {});
+            closeMoreMenu();
+            renderDocuments();
+            renderInfo();
+          }
+
+          async function deleteDoc() {
+            if (docs.length <= 1) {
+              alert('At least one document must remain.');
+              return;
+            }
+            const current = getActive();
+            if (!current || !confirm(`Delete "${current.title || 'Untitled'}"?`)) return;
+            const idx = docs.findIndex(d => d.id === current.id);
+            if (idx < 0) return;
+            if (MODE === 'account') {
+              await api('/api/pages/delete', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ id: current.id }),
+              });
+            }
+            docs.splice(idx, 1);
+            active = docs[Math.max(0, idx - 1)].id;
+            if (MODE === 'account') localStorage.setItem(REMOTE_ACTIVE_KEY, active);
+            else saveLocalState(docs, active);
+            await ensureLoaded(active);
+            input.value = getActive().content || '';
+            closeMoreMenu();
+            render();
+            renderDocuments();
+          }
+
+          function exportHtml() {
+            const current = getActive();
+            const title = current?.title || 'Markdown Export';
+            const html = [
+              '<!doctype html><html lang="en"><head><meta charset="utf-8">',
+              `<title>${escapeHtml(title)}</title>`,
+              '<meta name="viewport" content="width=device-width, initial-scale=1">',
+              '<style>body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;line-height:1.58;max-width:920px;margin:48px auto;padding:0 24px;color:#192338}pre{overflow:auto;padding:14px;background:#f4f6f8;border-radius:8px}table{border-collapse:collapse;width:100%}th,td{border:1px solid #d0d5dd;padding:8px 10px;text-align:left}img{max-width:100%}</style>',
+              '</head><body>',
+              preview.innerHTML,
+              '</body></html>',
+            ].join('');
+            const blob = new Blob([html], { type: 'text/html' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `${slugify(title)}.html`;
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            URL.revokeObjectURL(url);
+          }
+
+          function slugify(text) {
+            return String(text || 'markdown-document')
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-|-$/g, '') || 'markdown-document';
+          }
+
+          async function copyRenderedHtml() {
+            const old = copyBtn?.textContent;
             try {
               await navigator.clipboard.writeText(preview.innerHTML);
-              const old = copyBtn.textContent;
-              copyBtn.textContent = 'Copied!';
-              setTimeout(() => { copyBtn.textContent = old || 'Copy HTML'; }, 1200);
+              if (copyBtn) copyBtn.textContent = 'Copied';
             } catch {
               const tmp = document.createElement('textarea');
               tmp.value = preview.innerHTML;
               document.body.appendChild(tmp);
               tmp.select();
               document.execCommand('copy');
-              document.body.removeChild(tmp);
+              tmp.remove();
+              if (copyBtn) copyBtn.textContent = 'Copied';
+            }
+            if (copyBtn) setTimeout(() => { copyBtn.textContent = old || 'Copy HTML'; }, 1200);
+          }
+
+          async function shareMarkdown() {
+            const current = getActive();
+            const data = { title: current?.title || 'Markdown document', text: input.value };
+            if (navigator.share && navigator.canShare && navigator.canShare(data)) {
+              await navigator.share(data).catch(() => {});
+              return;
+            }
+            await navigator.clipboard?.writeText(input.value).catch(() => {});
+          }
+
+          function closeMoreMenu() {
+            moreMenu?.classList.remove('open');
+            moreButton?.setAttribute('aria-expanded', 'false');
+          }
+
+          function toggleBookmark() {
+            const current = getActive();
+            if (!current) return;
+            current.bookmarked = !current.bookmarked;
+            if (MODE === 'local') saveLocalState(docs, active);
+            renderInfo();
+          }
+
+          input.addEventListener('input', () => {
+            render();
+            setSaveState('Saving...', true);
+            clearTimeout(saveTimer);
+            saveTimer = setTimeout(() => {
+              persistCurrent().catch(() => setSaveState('Save failed', false));
+            }, 450);
+          });
+          newBtn?.addEventListener('click', () => newDoc().catch(() => {}));
+          renameBtn?.addEventListener('click', renameDoc);
+          deleteBtn?.addEventListener('click', () => deleteDoc().catch(() => {}));
+          copyBtn?.addEventListener('click', copyRenderedHtml);
+          exportHtmlBtn?.addEventListener('click', exportHtml);
+          exportPdfBtn?.addEventListener('click', () => window.print());
+          printButton?.addEventListener('click', () => window.print());
+          bookmarkButton?.addEventListener('click', toggleBookmark);
+          shareButton?.addEventListener('click', () => shareMarkdown().catch(() => {}));
+          helpButton?.addEventListener('click', () => alert('Split View keeps the raw Markdown editor open. Full Width hides the editor and shows the rendered document.'));
+          splitView?.addEventListener('click', () => setView('split'));
+          fullView?.addEventListener('click', () => setView('full'));
+          moreButton?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const open = !moreMenu?.classList.contains('open');
+            moreMenu?.classList.toggle('open', open);
+            moreButton.setAttribute('aria-expanded', String(open));
+          });
+          document.addEventListener('click', (e) => {
+            if (!moreMenu?.contains(e.target) && e.target !== moreButton) closeMoreMenu();
+          });
+          docSearch?.addEventListener('input', () => {
+            searchText = docSearch.value || '';
+            renderDocuments();
+          });
+          showAllDocs?.addEventListener('click', () => {
+            searchText = '';
+            if (docSearch) docSearch.value = '';
+            renderDocuments();
+          });
+          document.addEventListener('keydown', (e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+              e.preventDefault();
+              docSearch?.focus();
+              docSearch?.select();
             }
           });
+          decreaseFont?.addEventListener('click', () => {
+            readerSettings.fontSize = Math.max(12, Number(readerSettings.fontSize) - 1);
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+          increaseFont?.addEventListener('click', () => {
+            readerSettings.fontSize = Math.min(22, Number(readerSettings.fontSize) + 1);
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+          lineHeightSelect?.addEventListener('change', () => {
+            readerSettings.lineHeight = lineHeightSelect.value;
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+          widthSelect?.addEventListener('change', () => {
+            readerSettings.width = widthSelect.value;
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+          typeSelect?.addEventListener('change', () => {
+            readerSettings.type = typeSelect.value;
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+
+          (async () => {
+            applyReaderSettings();
+            await refreshAuth();
+            if (MODE === 'account') await loadAccountDocs();
+            else loadLocalDocs();
+            render();
+            renderDocuments();
+            setSaveState('Auto-saved', false);
+          })();
         }
 
-	        // Theme is owned by `public/shared/toolkit.js`.
-
-        (async () => {
-          await refreshAuth();
-          if (MODE === 'account') await loadAccountDocs();
-          else loadLocalDocs();
-          renderTabs();
-          render();
-        })();
-        }
         if (document.readyState === 'loading') {
           document.addEventListener('DOMContentLoaded', boot);
         } else {
           boot();
         }
       })();
-	    </script>
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Redesigns the Markdown Viewer around a document-reader UI with sidebar document management and a large rendered reading pane.
- Keeps raw Markdown editable in Split View while Full Width focuses on the rendered preview.

## Changes
- Rebuilds `public/markdown.html` with document search, document info, split/full view controls, reading settings, and export/share actions.
- Preserves the existing `textarea id="input"`, Markdown rendering, sanitization, MathJax, syntax highlighting, and local/account document persistence.
- Keeps account-backed documents lazy-loaded correctly so saved raw Markdown content remains editable after selection.

## Testing
- `npm test`
- Inline Markdown page scripts syntax-checked with Node.
- Verified `/markdown` served the updated layout locally with Wrangler.
