### PR TITLE
Update Euler preview UI

### DIFF
--- a/public/euler.html
+++ b/public/euler.html
@@ -8,98 +8,815 @@
     <script defer src="/shared/toolkit.js"></script>
     <style>
       :root { --red: #d93025; --green: #188038; }
-      [data-theme="dark"] { --red: #ff6b6b; --green: #4caf50; }
+      [data-theme='dark'] { --red: #ff6b6b; --green: #4caf50; }
       * { box-sizing: border-box; }
-      html, body { height: 100%; margin: 0; }
-      body { background: transparent; color: var(--fg); font-family: inherit; }
-      .app-header {
+      html, body { min-height: 100%; margin: 0; }
+      body.wt {
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.78), rgba(246, 248, 252, 0.94)),
+          var(--wt-bg);
+        color: #11182c;
+      }
+      [data-theme='dark'] body.wt {
+        background:
+          linear-gradient(180deg, rgba(9, 14, 30, 0.92), rgba(7, 11, 22, 0.98)),
+          var(--wt-bg);
+        color: var(--wt-fg);
+      }
+      body[data-wt-tool='euler'] .wt-header {
+        margin: 8px auto 0;
+        width: min(calc(100% - 32px), 1880px);
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 10px;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+        background: rgba(255, 255, 255, 0.9);
+      }
+      [data-theme='dark'] body[data-wt-tool='euler'] .wt-header {
+        border-color: rgba(226, 237, 255, 0.12);
+        background: rgba(15, 23, 42, 0.9);
+      }
+      body[data-wt-tool='euler'] .wt-header-inner {
+        max-width: none;
+        padding: 12px 18px;
+      }
+      body[data-wt-tool='euler'] .wt-logo-link {
+        width: 34px;
+        height: 34px;
+        border-radius: 8px;
+        color: #2563eb;
+        background: #eef4ff;
+      }
+      body[data-wt-tool='euler'] .wt-logo-link::after {
+        content: 'E';
+        font-weight: 800;
+        font-size: 0.9rem;
+      }
+      body[data-wt-tool='euler'] .wt-logo { display: none; }
+      body[data-wt-tool='euler'] .wt-toolname {
+        border-left: 0;
+        padding-left: 0;
+        color: inherit;
+        font-size: 1rem;
+        font-weight: 750;
+      }
+      body[data-wt-tool='euler'] .wt-actions > a[title='Home'] { display: none; }
+      body[data-wt-tool='euler'] .wt-btn {
+        min-height: 34px;
+        border-radius: 8px;
+        border-style: solid;
+        background: #fff;
+        box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+      }
+      [data-theme='dark'] body[data-wt-tool='euler'] .wt-btn { background: rgba(15, 23, 42, 0.8); }
+      body[data-wt-tool='euler'] #wtToggleTheme::before { content: '*'; }
+      body[data-wt-tool='euler'] #wtToggleTheme {
+        gap: 9px;
+        min-width: 106px;
+        justify-content: center;
+      }
+      .eu-shell {
+        width: min(calc(100% - 32px), 1880px);
+        margin: 12px auto 22px;
+        display: grid;
+        grid-template-columns: 450px minmax(0, 1fr);
+        gap: 24px;
+        align-items: start;
+      }
+      .eu-sidebar {
+        display: grid;
+        gap: 10px;
+      }
+      .eu-card,
+      .eu-reader {
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.92);
+        box-shadow: 0 14px 40px rgba(15, 23, 42, 0.08);
+      }
+      [data-theme='dark'] .eu-card,
+      [data-theme='dark'] .eu-reader {
+        border-color: rgba(226, 237, 255, 0.1);
+        background: rgba(15, 23, 42, 0.88);
+        box-shadow: 0 20px 48px rgba(0, 0, 0, 0.34);
+      }
+      .eu-card { padding: 20px; }
+      .eu-card-title {
+        margin: 0;
+        font-size: 0.95rem;
+        font-weight: 800;
+        letter-spacing: 0;
+      }
+      .eu-card-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .eu-icon-btn,
+      .eu-text-btn,
+      .eu-select,
+      .eu-field {
+        appearance: none;
+        border: 1px solid rgba(15, 23, 42, 0.12);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.95);
+        color: inherit;
+        font: inherit;
+      }
+      [data-theme='dark'] .eu-icon-btn,
+      [data-theme='dark'] .eu-text-btn,
+      [data-theme='dark'] .eu-select,
+      [data-theme='dark'] .eu-field {
+        border-color: rgba(226, 237, 255, 0.13);
+        background: rgba(7, 11, 22, 0.44);
+      }
+      .eu-icon-btn,
+      .eu-text-btn {
+        min-height: 34px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 8px 10px;
+        cursor: pointer;
+      }
+      .eu-icon-btn {
+        width: 38px;
+        padding: 0;
+      }
+      .eu-text-btn {
+        min-width: 88px;
+        font-size: 0.88rem;
+      }
+      .eu-text-btn.primary {
+        border-color: rgba(37, 99, 235, 0.28);
+        color: #1d4ed8;
+        background: #f7fbff;
+      }
+      [data-theme='dark'] .eu-text-btn.primary {
+        color: #93c5fd;
+        background: rgba(37, 99, 235, 0.12);
+      }
+      .eu-text-btn.danger { color: var(--wt-danger); }
+      .eu-icon {
+        width: 18px;
+        height: 18px;
+        display: inline-block;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+      .eu-search-wrap {
+        position: relative;
+        margin-top: 14px;
+      }
+      .eu-search-wrap .eu-icon {
+        position: absolute;
+        top: 50%;
+        left: 12px;
+        width: 17px;
+        height: 17px;
+        transform: translateY(-50%);
+        color: #667085;
+      }
+      .eu-field {
+        width: 100%;
+        min-height: 38px;
+        padding: 8px 50px 8px 38px;
+        outline: none;
+      }
+      .eu-kbd {
+        position: absolute;
+        top: 50%;
+        right: 10px;
+        transform: translateY(-50%);
+        min-width: 40px;
+        padding: 2px 5px;
+        border-radius: 5px;
+        background: rgba(15, 23, 42, 0.06);
+        color: #667085;
+        text-align: center;
+        font-size: 0.75rem;
+        font-weight: 700;
+      }
+      .eu-doc-list {
+        display: grid;
+        gap: 8px;
+        margin-top: 12px;
+      }
+      .eu-doc-item {
+        width: 100%;
+        display: grid;
+        grid-template-columns: 30px minmax(0, 1fr) 24px;
+        gap: 10px;
+        align-items: center;
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 7px;
+        background: #fff;
+        color: inherit;
+        padding: 11px 10px;
+        text-align: left;
+        cursor: pointer;
+      }
+      .eu-doc-item:hover { border-color: rgba(37, 99, 235, 0.32); }
+      .eu-doc-item.active {
+        border-color: #2563eb;
+        background: #eef5ff;
+        box-shadow: inset 3px 0 0 #2563eb;
+      }
+      [data-theme='dark'] .eu-doc-item {
+        border-color: rgba(226, 237, 255, 0.1);
+        background: rgba(7, 11, 22, 0.3);
+      }
+      [data-theme='dark'] .eu-doc-item.active {
+        border-color: #60a5fa;
+        background: rgba(37, 99, 235, 0.16);
+      }
+      .eu-doc-icon {
+        width: 24px;
+        height: 24px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 5px;
+        color: #2563eb;
+        background: #e8f0ff;
+      }
+      .eu-doc-title,
+      .eu-doc-subtitle {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .eu-doc-title { font-weight: 750; }
+      .eu-doc-subtitle {
+        margin-top: 2px;
+        color: #667085;
+        font-size: 0.78rem;
+      }
+      [data-theme='dark'] .eu-doc-subtitle,
+      [data-theme='dark'] .eu-muted { color: var(--wt-muted); }
+      .eu-more-dots {
+        color: #667085;
+        font-weight: 900;
+        letter-spacing: 1px;
+      }
+      .eu-link-btn {
+        appearance: none;
+        border: 0;
+        background: transparent;
+        color: #2563eb;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        margin: 12px auto 0;
+        padding: 4px 8px;
+        cursor: pointer;
+        font: inherit;
+        font-size: 0.86rem;
+      }
+      .eu-info-grid {
+        display: grid;
+        grid-template-columns: minmax(90px, 0.55fr) minmax(0, 1fr);
+        gap: 8px 18px;
+        margin-top: 18px;
+        font-size: 0.86rem;
+      }
+      .eu-info-grid dt {
+        color: #475467;
+        margin: 0;
+      }
+      .eu-info-grid dd {
+        margin: 0;
+        min-width: 0;
+        overflow-wrap: anywhere;
+      }
+      .eu-segment {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+        margin-top: 16px;
+      }
+      .eu-segment button {
+        min-height: 68px;
+        flex-direction: column;
+        gap: 7px;
+      }
+      .eu-segment button.active {
+        border-color: #2563eb;
+        box-shadow: inset 0 0 0 1px #2563eb;
+        color: #1d4ed8;
+        background: #f8fbff;
+      }
+      [data-theme='dark'] .eu-segment button.active {
+        color: #93c5fd;
+        background: rgba(37, 99, 235, 0.14);
+      }
+      .eu-setting-list {
+        display: grid;
+        gap: 10px;
+        margin-top: 16px;
+      }
+      .eu-setting-list label {
+        display: grid;
+        grid-template-columns: 1fr minmax(150px, 0.9fr);
+        gap: 12px;
+        align-items: center;
+        font-size: 0.86rem;
+      }
+      .eu-select {
+        min-height: 36px;
+        padding: 7px 10px;
+      }
+      .eu-stepper {
+        display: grid;
+        grid-template-columns: 36px 1fr 36px;
+        overflow: hidden;
+        border: 1px solid rgba(15, 23, 42, 0.12);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.95);
+      }
+      [data-theme='dark'] .eu-stepper {
+        border-color: rgba(226, 237, 255, 0.13);
+        background: rgba(7, 11, 22, 0.44);
+      }
+      .eu-stepper button {
+        border: 0;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+        font-size: 1rem;
+      }
+      .eu-stepper output {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 34px;
+        border-inline: 1px solid rgba(15, 23, 42, 0.08);
+      }
+      .eu-export-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 10px;
+        margin-top: 16px;
+      }
+      .eu-export-grid .wide { grid-column: 1 / -1; }
+      .eu-reader {
+        min-width: 0;
+        overflow: hidden;
+      }
+      .eu-reader-topbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 18px 34px 10px;
+      }
+      .eu-meta-line {
+        min-width: 0;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        color: #475467;
+        font-size: 0.88rem;
+      }
+      .eu-meta-line span:last-child {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .eu-reader-actions {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+      .eu-save-state {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        color: #0f766e;
+        white-space: nowrap;
+        font-size: 0.84rem;
+      }
+      .eu-reader-grid {
+        display: grid;
+        grid-template-columns: minmax(320px, 0.82fr) minmax(0, 1fr);
+        min-height: calc(100vh - 134px);
+      }
+      .eu-source-wrap {
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        border-top: 1px solid rgba(15, 23, 42, 0.08);
+        border-right: 1px solid rgba(15, 23, 42, 0.08);
+        background: #fbfcff;
+      }
+      [data-theme='dark'] .eu-source-wrap {
+        border-color: rgba(226, 237, 255, 0.1);
+        background: rgba(7, 11, 22, 0.3);
+      }
+      .eu-source-head {
+        min-height: 46px;
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 8px;
-        padding: 0.85rem 1.25rem;
-        border-bottom: 1px solid var(--border);
-        background: var(--header-bg);
-        color: var(--header-fg);
-        position: sticky;
-        top: 0;
-        z-index: 10;
-        box-shadow: 0 4px 16px rgba(0,0,0,0.24);
+        padding: 10px 14px;
+        border-bottom: 1px solid rgba(15, 23, 42, 0.08);
       }
-      .app-header h1 { margin: 0; font-size: 1.05rem; letter-spacing: 0.5px; text-transform: uppercase; }
-      .app-header .actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
-      .icon-btn { appearance: none; border: 1px solid var(--border); background: rgba(255,255,255,0.08); color: inherit; padding: 6px 10px; border-radius: 10px; font-size: 0.9rem; line-height: 1; display: inline-flex; align-items: center; gap: 8px; cursor: pointer; text-decoration: none; }
-      .icon-btn:hover { background: rgba(255,255,255,0.12); }
-      .icon { width: 16px; height: 16px; display: inline-block; }
-      .icon svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
-      .pill { font-size: .85rem; border: 1px solid var(--border); border-radius: 999px; padding: .25rem .65rem; background: var(--accent-soft); }
-      .pill.accent { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
-      .tabs { display: flex; align-items: center; gap: 8px; padding: 10px 14px; border-bottom: 1px solid var(--border); background: rgba(255,255,255,0.02); position: sticky; top: 58px; z-index: 9; backdrop-filter: blur(8px); }
-      .tab-list { display: flex; gap: 6px; flex-wrap: wrap; }
-      .tab { padding: 6px 10px; border: 1px solid var(--border); border-radius: 999px; background: var(--pane-bg); cursor: pointer; user-select: none; color: inherit; }
-      .tab.active { background: transparent; border-color: var(--accent); color: inherit; box-shadow: 0 0 0 2px rgba(47,124,246,0.22) inset; }
-      .tab input.tab-rename { font: inherit; color: inherit; background: transparent; border: 0; outline: none; padding: 0; margin: 0; min-width: 60px; width: 12ch; }
-      .tabs .spacer { flex: 1; }
-      .page { max-width: 1400px; margin: 0 auto; padding: 14px; }
-      .container { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
-      .pane { height: 100%; border: 1px solid var(--border); border-radius: 14px; background: var(--pane-bg); overflow: hidden; box-shadow: var(--shadow); }
-      textarea { width: 100%; height: 100%; padding: 1rem; border: 0; outline: none; resize: none; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 14px; line-height: 1.5; background: transparent; color: inherit; }
-      #preview { overflow: auto; padding: 1rem; }
-      .pe-quote { border-left: 3px solid var(--border); margin: .75rem 0; padding: .5rem .75rem; background: rgba(127,127,127,0.06); }
-      .pe-quote .pe-quote-head { font-size: .9rem; color: var(--muted); margin-bottom: .4rem; }
-      .pe-collapse { border: 1px solid var(--border); border-radius: 6px; overflow: hidden; margin: .75rem 0; }
-      .pe-collapse summary { cursor: pointer; padding: .4rem .6rem; background: rgba(127,127,127,0.08); font-weight: 600; }
-      .pe-collapse .pe-collapse-body { padding: .6rem .8rem; }
-      .pe-hide { color: transparent; background: currentColor; border-radius: 4px; padding: 0 .3rem; }
-      .pe-hide:hover, .pe-hide:focus { color: inherit; background: transparent; }
+      [data-theme='dark'] .eu-source-head { border-color: rgba(226, 237, 255, 0.1); }
+      .eu-source-title {
+        margin: 0;
+        font-size: 0.86rem;
+        font-weight: 800;
+      }
+      textarea#input {
+        width: 100%;
+        min-height: 540px;
+        flex: 1;
+        resize: none;
+        border: 0;
+        outline: none;
+        padding: 18px;
+        background: transparent;
+        color: inherit;
+        font-family: var(--wt-font-mono);
+        font-size: 14px;
+        line-height: 1.55;
+      }
+      .eu-preview-wrap {
+        min-width: 0;
+        overflow: auto;
+        border-top: 1px solid rgba(15, 23, 42, 0.08);
+      }
+      [data-theme='dark'] .eu-preview-wrap { border-color: rgba(226, 237, 255, 0.1); }
+      .eu-preview {
+        width: min(100%, var(--reader-width, 920px));
+        margin: 0 auto;
+        padding: 46px 36px 60px;
+        color: #192338;
+        font-family: var(--reader-font, var(--wt-font-sans));
+        font-size: var(--reader-font-size, 16px);
+        line-height: var(--reader-line-height, 1.58);
+      }
+      [data-theme='dark'] .eu-preview { color: #e6edff; }
+      .eu-preview > :first-child { margin-top: 0; }
+      .eu-preview h1 {
+        margin: 0 0 20px;
+        color: #07112b;
+        font-size: clamp(2rem, 3vw, 3rem);
+        line-height: 1.08;
+        letter-spacing: 0;
+      }
+      .eu-preview h2 {
+        margin-top: 32px;
+        padding-top: 22px;
+        border-top: 1px solid rgba(15, 23, 42, 0.12);
+        color: #0e172d;
+        font-size: 1.35rem;
+        line-height: 1.22;
+      }
+      [data-theme='dark'] .eu-preview h1,
+      [data-theme='dark'] .eu-preview h2 { color: #f3f7ff; }
+      .eu-preview p { margin: 0 0 16px; }
+      .eu-preview a {
+        color: #2563eb;
+        text-decoration-thickness: 1px;
+        text-underline-offset: 2px;
+      }
+      .eu-preview pre {
+        overflow: auto;
+        padding: 14px;
+        border: 1px solid rgba(15, 23, 42, 0.1);
+        border-radius: 8px;
+        background: rgba(15, 23, 42, 0.05);
+      }
+      .eu-preview code {
+        font-family: var(--wt-font-mono);
+        font-size: 0.92em;
+      }
+      .eu-preview ol,
+      .eu-preview ul { padding-left: 1.35em; }
+      .eu-preview img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+      }
+      .pe-quote {
+        border-left: 4px solid rgba(37, 99, 235, 0.32);
+        margin: 18px 0;
+        padding: 10px 14px;
+        border-radius: 0 8px 8px 0;
+        background: rgba(15, 23, 42, 0.04);
+      }
+      .pe-quote .pe-quote-head {
+        margin-bottom: 6px;
+        color: #667085;
+        font-size: 0.9rem;
+        font-weight: 750;
+      }
+      .pe-collapse {
+        border: 1px solid rgba(15, 23, 42, 0.12);
+        border-radius: 8px;
+        overflow: hidden;
+        margin: 18px 0;
+      }
+      .pe-collapse summary {
+        cursor: pointer;
+        padding: 10px 12px;
+        background: rgba(15, 23, 42, 0.05);
+        font-weight: 750;
+      }
+      .pe-collapse .pe-collapse-body {
+        padding: 12px 14px;
+      }
+      .pe-hide {
+        color: transparent;
+        background: currentColor;
+        border-radius: 5px;
+        padding: 0 0.3rem;
+      }
+      .pe-hide:hover,
+      .pe-hide:focus {
+        color: inherit;
+        background: transparent;
+      }
       .pe-red { color: var(--red); }
       .pe-green { color: var(--green); }
-      pre { background: rgba(127,127,127,0.1); padding: .75rem; overflow: auto; border-radius: 6px; }
-      code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
-      .footer { font-size: .85rem; color: var(--muted); padding: .5rem 1rem; border-top: 1px solid var(--border); }
       .pe-center { text-align: center; }
       .pe-right { text-align: right; }
-      img { max-width: 100%; height: auto; }
-      a { color: var(--accent); }
-      @media (max-width: 900px) { .container { grid-template-columns: 1fr; grid-auto-rows: 50vh 50vh; } }
+      .eu-reader.full .eu-reader-grid {
+        display: block;
+      }
+      .eu-reader.full .eu-source-wrap {
+        display: none;
+      }
+      .eu-reader.full .eu-preview-wrap {
+        min-height: calc(100vh - 134px);
+      }
+      .eu-reader.full .eu-preview {
+        padding-top: 46px;
+      }
+      .eu-menu-wrap {
+        position: relative;
+      }
+      .eu-menu {
+        position: absolute;
+        top: calc(100% + 8px);
+        right: 0;
+        z-index: 20;
+        min-width: 180px;
+        display: none;
+        padding: 8px;
+        border: 1px solid rgba(15, 23, 42, 0.1);
+        border-radius: 8px;
+        background: #fff;
+        box-shadow: 0 18px 44px rgba(15, 23, 42, 0.16);
+      }
+      [data-theme='dark'] .eu-menu {
+        border-color: rgba(226, 237, 255, 0.12);
+        background: #0f172a;
+      }
+      .eu-menu.open { display: grid; gap: 4px; }
+      .eu-menu button {
+        justify-content: flex-start;
+        width: 100%;
+        border: 0;
+        box-shadow: none;
+        background: transparent;
+      }
+      .eu-muted { color: #667085; }
+      @media (max-width: 1180px) {
+        .eu-shell {
+          grid-template-columns: 360px minmax(0, 1fr);
+          gap: 14px;
+        }
+        .eu-reader-grid {
+          grid-template-columns: 1fr;
+        }
+        .eu-source-wrap {
+          border-right: 0;
+        }
+      }
+      @media (max-width: 860px) {
+        body[data-wt-tool='euler'] .wt-header,
+        .eu-shell {
+          width: min(calc(100% - 20px), 1880px);
+        }
+        .eu-shell {
+          grid-template-columns: 1fr;
+        }
+        .eu-sidebar {
+          order: 2;
+        }
+        .eu-reader {
+          order: 1;
+        }
+        .eu-reader-topbar {
+          padding-inline: 16px;
+          flex-wrap: wrap;
+        }
+        .eu-reader-actions {
+          width: 100%;
+          justify-content: flex-end;
+        }
+        .eu-preview {
+          padding: 30px 20px 44px;
+        }
+        textarea#input {
+          min-height: 420px;
+        }
+      }
+      @media print {
+        body[data-wt-tool='euler'] .wt-header,
+        .eu-sidebar,
+        .eu-source-wrap,
+        .eu-reader-topbar {
+          display: none !important;
+        }
+        .eu-shell,
+        .eu-reader,
+        .eu-preview-wrap,
+        .eu-preview {
+          display: block;
+          width: 100%;
+          margin: 0;
+          padding: 0;
+          border: 0;
+          box-shadow: none;
+        }
+      }
     </style>
 
     <script>
-      // MathJax v3 configuration (use $...$ and $$...$$)
       window.MathJax = {
         tex: {
           inlineMath: [['$', '$']],
-          displayMath: [['$$','$$'], ['\\[', '\\]']]
+          displayMath: [['$$','$$'], ['\\[', '\\]']],
         },
-        options: { skipHtmlTags: ['script','noscript','style','textarea','pre','code'] }
+        options: { skipHtmlTags: ['script','noscript','style','textarea','pre','code'] },
       };
     </script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.7/dist/purify.min.js"></script>
     <script async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
-    <!-- Highlight.js theme (swapped dynamically for dark/light) -->
-    <link id="hljs-theme" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github.min.css">
-    <!-- Highlight.js full build (includes all languages). Load synchronously so it's ready before our script runs. -->
+    <link id="hljs-theme" rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github.min.css" />
     <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/highlight.min.js"></script>
   </head>
   <body class="wt" data-wt-tool="euler" data-wt-title="Euler Preview">
     <div class="wt-header" role="banner"></div>
     <template id="wtHeaderExtra">
-      <span id="modePill" class="pill">Checking…</span>
-      <button id="copyHtml" class="wt-btn wt-btn-ghost" type="button" title="Copy rendered HTML">Copy HTML</button>
+      <button id="helpButton" class="wt-btn" type="button" title="Euler preview help" aria-label="Euler preview help">?</button>
+      <button id="shareButton" class="wt-btn" type="button" title="Share Euler source" aria-label="Share Euler source">
+        <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7"/><path d="M12 16V4"/><path d="m7 9 5-5 5 5"/></svg>
+      </button>
       <div id="authArea"></div>
     </template>
-    <nav class="tabs">
-      <div id="tabList" class="tab-list" role="tablist" aria-label="Euler documents"></div>
-      <div class="spacer"></div>
-      <button id="newTab" class="wt-btn wt-btn-ghost" title="New document" type="button">+ New</button>
-      <button id="renameTab" class="wt-btn wt-btn-ghost" title="Rename document" type="button">Rename</button>
-      <button id="deleteTab" class="wt-btn wt-btn-danger" title="Delete document" type="button">Delete</button>
-    </nav>
 
-    <div class="page wt-page">
-    <div class="container">
-      <section class="pane">
-        <textarea id="input" placeholder="Paste Project Euler forum text here...">[h1]Welcome[/h1]
+    <main class="eu-shell">
+      <aside class="eu-sidebar" aria-label="Euler documents and settings">
+        <section class="eu-card" aria-labelledby="documentsTitle">
+          <div class="eu-card-head">
+            <h2 id="documentsTitle" class="eu-card-title">Documents</h2>
+            <button id="newTab" class="eu-text-btn primary" type="button" title="New document">
+              <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+              New
+            </button>
+          </div>
+          <div class="eu-search-wrap">
+            <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m16 16 4 4"/></svg>
+            <input id="docSearch" class="eu-field" type="search" placeholder="Search documents..." autocomplete="off" />
+            <span class="eu-kbd">Ctrl K</span>
+          </div>
+          <div id="tabList" class="eu-doc-list" role="tablist" aria-label="Euler documents"></div>
+          <button id="showAllDocs" class="eu-link-btn" type="button">
+            <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 3h8l4 4v14H8z"/><path d="M16 3v5h4"/><path d="M4 7v14h4"/></svg>
+            Show all documents
+          </button>
+        </section>
+
+        <section class="eu-card" aria-labelledby="documentInfoTitle">
+          <h2 id="documentInfoTitle" class="eu-card-title">Document Info</h2>
+          <dl class="eu-info-grid">
+            <dt>Title</dt><dd id="infoTitle">Untitled</dd>
+            <dt>Source</dt><dd id="infoSource">Local only</dd>
+            <dt>Created</dt><dd id="infoCreated">-</dd>
+            <dt>Last updated</dt><dd id="infoUpdated">-</dd>
+            <dt>Size</dt><dd id="infoSize">0 B</dd>
+            <dt>Words</dt><dd id="infoWords">0</dd>
+            <dt>Reading time</dt><dd id="infoReadingTime">0 min</dd>
+          </dl>
+        </section>
+
+        <section class="eu-card" aria-labelledby="viewTitle">
+          <h2 id="viewTitle" class="eu-card-title">View</h2>
+          <div class="eu-segment">
+            <button id="splitView" class="eu-text-btn active" type="button" aria-pressed="true">
+              <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M12 4v16"/></svg>
+              Split View
+            </button>
+            <button id="fullView" class="eu-text-btn" type="button" aria-pressed="false">
+              <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="5" y="4" width="14" height="16" rx="2"/><path d="M9 4v16"/></svg>
+              Full Width
+            </button>
+          </div>
+        </section>
+
+        <section class="eu-card" aria-labelledby="readingTitle">
+          <h2 id="readingTitle" class="eu-card-title">Reading</h2>
+          <div class="eu-setting-list">
+            <label>
+              <span>Font size</span>
+              <span class="eu-stepper">
+                <button id="decreaseFont" type="button" title="Decrease font size">-</button>
+                <output id="fontSizeValue">16px</output>
+                <button id="increaseFont" type="button" title="Increase font size">+</button>
+              </span>
+            </label>
+            <label>
+              <span>Line height</span>
+              <select id="lineHeightSelect" class="eu-select">
+                <option value="1.45">Compact</option>
+                <option value="1.58" selected>Comfortable</option>
+                <option value="1.75">Relaxed</option>
+              </select>
+            </label>
+            <label>
+              <span>Width</span>
+              <select id="widthSelect" class="eu-select">
+                <option value="760px">Medium (760px)</option>
+                <option value="920px" selected>Wide (920px)</option>
+                <option value="1120px">Extra wide</option>
+              </select>
+            </label>
+            <label>
+              <span>Typography</span>
+              <select id="typeSelect" class="eu-select">
+                <option value="system" selected>System</option>
+                <option value="serif">Serif</option>
+                <option value="mono">Mono</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
+        <section class="eu-card" aria-labelledby="exportTitle">
+          <h2 id="exportTitle" class="eu-card-title">Export &amp; Share</h2>
+          <div class="eu-export-grid">
+            <button id="exportHtml" class="eu-text-btn" type="button">
+              <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m8 9-4 3 4 3"/><path d="m16 9 4 3-4 3"/><path d="m14 4-4 16"/></svg>
+              Export as HTML
+            </button>
+            <button id="exportPdf" class="eu-text-btn" type="button">
+              <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M9 15h6"/></svg>
+              Export as PDF
+            </button>
+            <button id="copyHtml" class="eu-text-btn wide" type="button">
+              <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><rect x="2" y="2" width="13" height="13" rx="2"/></svg>
+              Copy HTML
+            </button>
+          </div>
+        </section>
+      </aside>
+
+      <section id="reader" class="eu-reader" aria-label="Euler reader and raw editor">
+        <div class="eu-reader-topbar">
+          <div class="eu-meta-line">
+            <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4"/><path d="M8 2v4"/><path d="M3 10h18"/></svg>
+            <span id="readerMeta">Untitled</span>
+          </div>
+          <div class="eu-reader-actions">
+            <span id="saveState" class="eu-save-state">
+              <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+              Auto-saved
+            </span>
+            <button id="bookmarkButton" class="eu-icon-btn" type="button" title="Bookmark document" aria-label="Bookmark document">
+              <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M19 21 12 17 5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+            </button>
+            <button id="printButton" class="eu-icon-btn" type="button" title="Print document" aria-label="Print document">
+              <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 9V2h12v7"/><path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"/><path d="M6 14h12v8H6z"/></svg>
+            </button>
+            <span class="eu-menu-wrap">
+              <button id="moreButton" class="eu-icon-btn" type="button" title="More actions" aria-label="More actions" aria-expanded="false">
+                <svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+              </button>
+              <span id="moreMenu" class="eu-menu" role="menu">
+                <button id="renameTab" class="eu-text-btn" type="button" role="menuitem">Rename document</button>
+                <button id="deleteTab" class="eu-text-btn danger" type="button" role="menuitem">Delete document</button>
+              </span>
+            </span>
+          </div>
+        </div>
+        <div class="eu-reader-grid">
+          <section class="eu-source-wrap" aria-label="Raw Euler forum source editor">
+            <div class="eu-source-head">
+              <h2 class="eu-source-title">Raw Euler Source</h2>
+              <span id="sourceHint" class="eu-muted">Editable forum text</span>
+            </div>
+            <textarea id="input" spellcheck="false" placeholder="Paste Project Euler forum text here...">[h1]Welcome[/h1]
 
 You can use [b]BBCode[/b], inline TeX like $E=mc^2$, and blocks:
 
@@ -126,535 +843,782 @@ List:[list=1]
 [/list]
 
 Hidden: [hide]Spoiler text[/hide], colors: [r]red[/r] and [g]green[/g].
-        </textarea>
+</textarea>
+          </section>
+          <section class="eu-preview-wrap" aria-label="Rendered Euler preview">
+            <article id="preview" class="eu-preview"></article>
+          </section>
+        </div>
       </section>
-      <section id="preview" class="pane"></section>
-    </div>
-    </div>
-    
+    </main>
 
     <script>
       (function() {
         function boot() {
-        const TOOL = 'euler';
-        const LOCAL_STORAGE_KEY = 'euler_docs_v1';
-        const LOCAL_ACTIVE_KEY = 'euler_active_v1';
-        const REMOTE_ACTIVE_KEY = 'euler_active_remote_v1';
-        const root = document.documentElement;
-	
-        function syncHighlightTheme(theme) {
-          const link = document.getElementById('hljs-theme');
-          if (link && link.tagName === 'LINK') {
-            const base = 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/';
-            link.setAttribute('href', theme === 'dark' ? base + 'github-dark-dimmed.min.css' : base + 'github.min.css');
+          const TOOL = 'euler';
+          const LOCAL_STORAGE_KEY = 'euler_docs_v1';
+          const LOCAL_ACTIVE_KEY = 'euler_active_v1';
+          const REMOTE_ACTIVE_KEY = 'euler_active_remote_v1';
+          const READER_SETTINGS_KEY = 'euler_reader_settings_v1';
+          const DEFAULT_CONTENT = `[h1]Welcome[/h1]\n\nYou can use [b]BBCode[/b], inline TeX like $E=mc^2$, and blocks:\n\n$$\n\\int_{-\\infty}^{\\infty} e^{-x^2} \\, dx = \\sqrt{\\pi}\n$$\n\n[quote=\"euler\"]Obvious is the most dangerous word in mathematics.[/quote]\n\n[collapse=Code Example]\n[code=python]\n# Code highlighting demo\ndef fib(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a\nprint(fib(10))\n[/code]\n[/collapse]\n\nList:[list=1]\n[*] First\n[*] Second\n[/list]\n\nHidden: [hide]Spoiler text[/hide], colors: [r]red[/r] and [g]green[/g].\n`;
+          const root = document.documentElement;
+
+          function $(id) {
+            return document.getElementById(id);
           }
-        }
-        syncHighlightTheme(root.getAttribute('data-theme') || 'light');
-        window.addEventListener('wt-theme-change', (ev) => syncHighlightTheme(ev.detail?.theme || 'light'));
 
-        const input = document.getElementById('input');
-        const preview = document.getElementById('preview');
-        const tabList = document.getElementById('tabList');
-        const newBtn = document.getElementById('newTab');
-        const renameBtn = document.getElementById('renameTab');
-        const deleteBtn = document.getElementById('deleteTab');
-        const authArea = document.getElementById('authArea');
-        const modePill = document.getElementById('modePill');
-        if (!input || !preview) return;
+          const input = $('input');
+          const preview = $('preview');
+          const tabList = $('tabList');
+          const newBtn = $('newTab');
+          const renameBtn = $('renameTab');
+          const deleteBtn = $('deleteTab');
+          const copyBtn = $('copyHtml');
+          const authArea = $('authArea');
+          const reader = $('reader');
+          const splitView = $('splitView');
+          const fullView = $('fullView');
+          const saveState = $('saveState');
+          const docSearch = $('docSearch');
+          const showAllDocs = $('showAllDocs');
+          const moreButton = $('moreButton');
+          const moreMenu = $('moreMenu');
+          const exportHtmlBtn = $('exportHtml');
+          const exportPdfBtn = $('exportPdf');
+          const printButton = $('printButton');
+          const bookmarkButton = $('bookmarkButton');
+          const shareButton = $('shareButton');
+          const helpButton = $('helpButton');
+          const fontSizeValue = $('fontSizeValue');
+          const decreaseFont = $('decreaseFont');
+          const increaseFont = $('increaseFont');
+          const lineHeightSelect = $('lineHeightSelect');
+          const widthSelect = $('widthSelect');
+          const typeSelect = $('typeSelect');
+          if (!input || !preview) return;
 
-        async function api(path, opts={}) {
-          const res = await fetch(path, Object.assign({ credentials: 'include' }, opts));
-          if (!res.ok) throw new Error(await res.text());
-          return res.json();
-        }
-
-        let AUTH = { loggedIn: false, user: null };
-        let MODE = 'local'; // 'local' | 'account'
-
-        let docs = [];
-        let active = '';
-
-        function loadLocalState() {
-          let d = [];
-          try { d = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || '[]'); } catch {}
-          let a = localStorage.getItem(LOCAL_ACTIVE_KEY) || (d[0]?.id ?? '');
-          return { docs: d, active: a };
-        }
-        function saveLocalState(d, a) {
-          localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(d));
-          if (a) localStorage.setItem(LOCAL_ACTIVE_KEY, a);
-        }
-
-        function setModePill() {
-          if (!modePill) return;
-          if (MODE === 'account') {
-            modePill.textContent = 'Account storage';
-            modePill.classList.add('accent');
-          } else {
-            modePill.textContent = 'Local only';
-            modePill.classList.remove('accent');
-          }
-        }
-
-        async function refreshAuth() {
-          try {
-            const me = await api('/api/auth/me');
-            AUTH = { loggedIn: !!me.loggedIn, user: me.user || null };
-          } catch {
-            AUTH = { loggedIn: false, user: null };
-          }
-          MODE = AUTH.loggedIn ? 'account' : 'local';
-          setModePill();
-          renderAuth();
-        }
-
-	        function renderAuth() {
-	          if (!authArea) return;
-	          authArea.innerHTML = '';
-	          if (!AUTH.loggedIn) {
-	            const next = encodeURIComponent(location.pathname + location.search);
-	            const a = document.createElement('a');
-	            a.className = 'wt-btn wt-btn-primary';
-	            a.href = `/auth/google/login?returnTo=${next}`;
-	            a.textContent = 'Sign in';
-	            authArea.appendChild(a);
-	            return;
-	          }
-          const u = AUTH.user || {};
-          const span = document.createElement('span');
-          span.style.fontSize = '0.9rem';
-          span.style.opacity = '0.9';
-          span.textContent = (u.email || u.name || 'Signed in');
-	          const btn = document.createElement('button');
-	          btn.className = 'wt-btn wt-btn-ghost';
-	          btn.type = 'button';
-	          btn.textContent = 'Sign out';
-	          btn.addEventListener('click', async () => {
-	            try { await api('/api/auth/logout', { method: 'POST' }); } catch {}
-	            location.reload();
-	          });
-          authArea.appendChild(span);
-          authArea.appendChild(btn);
-        }
-
-        // Map common aliases to highlight.js language IDs
-        function normalizeLang(lang) {
-          if (!lang) return '';
-          let id = String(lang).trim().toLowerCase();
-          id = id.replace(/^language-/, '').replace(/[^a-z0-9+#-]+/g, '');
-          const map = {
-            js: 'javascript', mjs: 'javascript', cjs: 'javascript', node: 'javascript',
-            ts: 'typescript', tsx: 'typescript', jsx: 'javascript',
-            cplusplus: 'cpp', 'c++': 'cpp', cpp: 'cpp',
-            csharp: 'csharp', 'c#': 'csharp', cs: 'csharp',
-            sh: 'bash', zsh: 'bash', shell: 'bash', console: 'bash',
-            ps1: 'powershell', pwsh: 'powershell',
-            py: 'python',
-            rb: 'ruby',
-            tf: 'hcl', terraform: 'hcl',
-            yml: 'yaml'
-          };
-          return map[id] || id;
-        }
-
-        function uid() { return 'd_' + Math.random().toString(36).slice(2, 9); }
-        const DEFAULT_CONTENT = `[h1]Welcome[/h1]\n\nYou can use [b]BBCode[/b], inline TeX like $E=mc^2$, and blocks:\n\n$$\n\\int_{-\\infty}^{\\infty} e^{-x^2} \\, dx = \\sqrt{\\pi}\n$$\n\n[quote=\"euler\"]Obvious is the most dangerous word in mathematics.[/quote]\n\n[collapse=Code Example]\n[code=python]\n# Code highlighting demo\ndef fib(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a\nprint(fib(10))\n[/code]\n[/collapse]\n\nList:[list=1]\n[*] First\n[*] Second\n[/list]\n\nHidden: [hide]Spoiler text[/hide], colors: [r]red[/r] and [g]green[/g].\n`;
-        function getActive() { return docs.find(d => d.id === active) || docs[0]; }
-
-        function escapeHtml(s) {
-          return s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c]));
-        }
-
-        function renderPE(src) {
-          if (!src) return '';
-          let text = src;
-
-          // Extract [code] blocks to avoid parsing inside
-          const codeStore = [];
-          text = text.replace(/\[code(?:=([^\]]+))?\]([\s\S]*?)\[\/code\]/gi, (m, langParam, body) => {
-            let lang = null, noHighlight = false, forceAuto = false;
-            if (langParam) {
-              let p = String(langParam).trim();
-              if (p.includes('*')) { noHighlight = true; p = p.replace('*', ''); }
-              if (p.includes('?')) { forceAuto = true; p = p.replace('?', ''); }
-              p = p.trim();
-              if (p) lang = normalizeLang(p.toLowerCase());
+          function syncHighlightTheme(theme) {
+            const link = $('hljs-theme');
+            if (link && link.tagName === 'LINK') {
+              const base = 'https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/';
+              link.setAttribute('href', theme === 'dark' ? base + 'github-dark-dimmed.min.css' : base + 'github.min.css');
             }
-            const idx = codeStore.push({ lang, noHighlight, forceAuto, code: body }) - 1;
-            return `\uE000CODE${idx}\uE000`;
-          });
+          }
+          syncHighlightTheme(root.getAttribute('data-theme') || 'light');
+          window.addEventListener('wt-theme-change', (ev) => syncHighlightTheme(ev.detail?.theme || 'light'));
 
-          // Basic formatting tags
-          const replacements = [
-            { re: /\[b\]([\s\S]*?)\[\/b\]/gi, out: '<strong>$1</strong>' },
-            { re: /\[i\]([\s\S]*?)\[\/i\]/gi, out: '<em>$1</em>' },
-            { re: /\[s\]([\s\S]*?)\[\/s\]/gi, out: '<del>$1</del>' },
-            { re: /\[sup\]([\s\S]*?)\[\/sup\]/gi, out: '<sup>$1</sup>' },
-            { re: /\[sub\]([\s\S]*?)\[\/sub\]/gi, out: '<sub>$1</sub>' },
-            { re: /\[r\]([\s\S]*?)\[\/r\]/gi, out: '<span class="pe-red">$1</span>' },
-            { re: /\[g\]([\s\S]*?)\[\/g\]/gi, out: '<span class="pe-green">$1</span>' },
-            { re: /\[h1\]([\s\S]*?)\[\/h1\]/gi, out: '<h1>$1<\/h1>' },
-            { re: /\[h2\]([\s\S]*?)\[\/h2\]/gi, out: '<h2>$1<\/h2>' },
-            { re: /\[center\]([\s\S]*?)\[\/center\]/gi, out: '<div class="pe-center">$1<\/div>' },
-            { re: /\[right\]([\s\S]*?)\[\/right\]/gi, out: '<div class="pe-right">$1<\/div>' },
-            { re: /\[img\]([\s\S]*?)\[\/img\]/gi, out: '<img src="$1" alt="image" />' },
-            { re: /\[url\]([\s\S]*?)\[\/url\]/gi, out: '<a href="$1" target="_blank" rel="noopener noreferrer">$1<\/a>' },
-            { re: /\[url=([^\]]+)\]([\s\S]*?)\[\/url\]/gi, out: '<a href="$1" target="_blank" rel="noopener noreferrer">$2<\/a>' },
-            { re: /\[hide\]([\s\S]*?)\[\/hide\]/gi, out: '<span class="pe-hide" tabindex="0">$1<\/span>' },
-          ];
-          replacements.forEach(r => { text = text.replace(r.re, r.out); });
+          async function api(path, opts = {}) {
+            const res = await fetch(path, Object.assign({ credentials: 'include' }, opts));
+            if (!res.ok) throw new Error(await res.text());
+            return res.json();
+          }
 
-          // [quote] and [quote=...] blocks
-          text = text.replace(/\[quote(?:=([^\]]+))?\]([\s\S]*?)\[\/quote\]/gi, (m, who, body) => {
-            let head = '';
-            if (who) {
-              let w = String(who).trim();
-              w = w.replace(/^"|"$/g, '');
-              if (/^\d+$/.test(w)) head = `<div class="pe-quote-head">User ${w} said<\/div>`;
-              else head = `<div class="pe-quote-head">${escapeHtml(w)} said<\/div>`;
+          let AUTH = { loggedIn: false, user: null };
+          let MODE = 'local';
+          let docs = [];
+          let active = '';
+          let searchText = '';
+          let saveTimer;
+          let readerSettings = loadReaderSettings();
+
+          function uid() {
+            return 'd_' + Math.random().toString(36).slice(2, 9);
+          }
+
+          function nowIso() {
+            return new Date().toISOString();
+          }
+
+          function normalizeDoc(doc, index) {
+            const created = doc.created_at || doc.createdAt || nowIso();
+            const updated = doc.updated_at || doc.updatedAt || created;
+            return {
+              id: String(doc.id || uid()),
+              title: String(doc.title || `Doc ${index + 1}`),
+              content: doc.content === null ? null : (typeof doc.content === 'string' ? doc.content : doc.content ?? ''),
+              created_at: created,
+              updated_at: updated,
+              bookmarked: !!doc.bookmarked,
+            };
+          }
+
+          function loadLocalState() {
+            let d = [];
+            try { d = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || '[]'); } catch {}
+            d = Array.isArray(d) ? d.map(normalizeDoc) : [];
+            const a = localStorage.getItem(LOCAL_ACTIVE_KEY) || (d[0]?.id ?? '');
+            return { docs: d, active: a };
+          }
+
+          function saveLocalState(d, a) {
+            localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(d));
+            if (a) localStorage.setItem(LOCAL_ACTIVE_KEY, a);
+          }
+
+          function loadReaderSettings() {
+            const defaults = { fontSize: 16, lineHeight: '1.58', width: '920px', type: 'system', view: 'split' };
+            try {
+              const saved = JSON.parse(localStorage.getItem(READER_SETTINGS_KEY) || '{}');
+              return Object.assign(defaults, saved || {});
+            } catch {
+              return defaults;
             }
-            return `<div class="pe-quote">${head}<div>${body}<\/div><\/div>`;
-          });
+          }
 
-          // [collapse] and [collapse=Title]
-          text = text.replace(/\[collapse(?:=([^\]]+))?\]([\s\S]*?)\[\/collapse\]/gi, (m, title, body) => {
-            const t = title ? escapeHtml(String(title)) : 'Details';
-            return `<details class="pe-collapse"><summary>${t}<\/summary><div class="pe-collapse-body">${body}<\/div><\/details>`;
-          });
+          function saveReaderSettings() {
+            localStorage.setItem(READER_SETTINGS_KEY, JSON.stringify(readerSettings));
+          }
 
-          // [list] blocks with [*] items and optional type/start like [list=i@3]
-          function replaceLists(str) {
-            return str.replace(/\[list(?:=([^\]@\n]+)?(?:@([0-9]+))?)?\]([\s\S]*?)\[\/list\]/gi, (m, type, start, body) => {
-              const items = [];
-              const reItem = /\[\*\](.*?)(?=(?:\n\[\*\])|$)/gs;
-              let match; let content = body.trim();
-              while ((match = reItem.exec(content)) !== null) {
-                items.push(match[1].trim());
+          function applyReaderSettings() {
+            const fontSize = Math.min(22, Math.max(12, Number(readerSettings.fontSize) || 16));
+            readerSettings.fontSize = fontSize;
+            preview.style.setProperty('--reader-font-size', `${fontSize}px`);
+            preview.style.setProperty('--reader-line-height', readerSettings.lineHeight || '1.58');
+            preview.style.setProperty('--reader-width', readerSettings.width || '920px');
+            const fontMap = {
+              system: 'var(--wt-font-sans)',
+              serif: 'var(--wt-font-serif)',
+              mono: 'var(--wt-font-mono)',
+            };
+            preview.style.setProperty('--reader-font', fontMap[readerSettings.type] || fontMap.system);
+            if (fontSizeValue) fontSizeValue.textContent = `${fontSize}px`;
+            if (lineHeightSelect) lineHeightSelect.value = readerSettings.lineHeight || '1.58';
+            if (widthSelect) widthSelect.value = readerSettings.width || '920px';
+            if (typeSelect) typeSelect.value = readerSettings.type || 'system';
+            setView(readerSettings.view === 'full' ? 'full' : 'split', false);
+          }
+
+          function setView(view, persist = true) {
+            readerSettings.view = view;
+            reader?.classList.toggle('full', view === 'full');
+            splitView?.classList.toggle('active', view !== 'full');
+            fullView?.classList.toggle('active', view === 'full');
+            splitView?.setAttribute('aria-pressed', String(view !== 'full'));
+            fullView?.setAttribute('aria-pressed', String(view === 'full'));
+            if (persist) saveReaderSettings();
+          }
+
+          function getActive() {
+            return docs.find(d => d.id === active) || docs[0];
+          }
+
+          function formatDate(value) {
+            if (!value) return '-';
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) return '-';
+            return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+          }
+
+          function formatRange(doc) {
+            if (!doc) return 'No document selected';
+            const dates = [doc.created_at, doc.updated_at].filter(Boolean).map(v => new Date(v));
+            if (!dates.length || dates.some(d => Number.isNaN(d.getTime()))) return doc.title || 'Untitled';
+            return `${doc.title || 'Untitled'}, ${formatDate(dates[0])} to ${formatDate(dates[dates.length - 1])}`;
+          }
+
+          function byteSize(text) {
+            return new Blob([text || '']).size;
+          }
+
+          function formatBytes(bytes) {
+            if (bytes < 1024) return `${bytes} B`;
+            if (bytes < 1024 * 1024) return `~${Math.round(bytes / 1024)} KB`;
+            return `~${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+          }
+
+          function wordCount(text) {
+            const words = String(text || '').replace(/\[[^\]]+\]/g, ' ').trim().match(/\b[\w'-]+\b/g);
+            return words ? words.length : 0;
+          }
+
+          function readingMinutes(words) {
+            return Math.max(1, Math.ceil(words / 240));
+          }
+
+          function excerpt(text) {
+            const first = String(text || '')
+              .replace(/\[[^\]]+\]/g, '')
+              .split('\n')
+              .map(line => line.trim())
+              .filter(Boolean)[0] || 'Euler forum preview';
+            return first.slice(0, 74);
+          }
+
+          function setSaveState(label, saving = false) {
+            if (!saveState) return;
+            saveState.lastChild.textContent = ` ${label}`;
+            saveState.style.color = saving ? '#b45309' : '#0f766e';
+          }
+
+          async function refreshAuth() {
+            try {
+              const me = await api('/api/auth/me');
+              AUTH = { loggedIn: !!me.loggedIn, user: me.user || null };
+            } catch {
+              AUTH = { loggedIn: false, user: null };
+            }
+            MODE = AUTH.loggedIn ? 'account' : 'local';
+            renderAuth();
+          }
+
+          function renderAuth() {
+            if (!authArea) return;
+            authArea.innerHTML = '';
+            if (!AUTH.loggedIn) {
+              const next = encodeURIComponent(location.pathname + location.search);
+              const a = document.createElement('a');
+              a.className = 'wt-btn wt-btn-primary';
+              a.href = `/auth/google/login?returnTo=${next}`;
+              a.textContent = 'Sign in';
+              authArea.appendChild(a);
+              return;
+            }
+            const u = AUTH.user || {};
+            const span = document.createElement('span');
+            span.textContent = u.email || u.name || 'Signed in';
+            const btn = document.createElement('button');
+            btn.className = 'wt-btn wt-btn-ghost';
+            btn.type = 'button';
+            btn.textContent = 'Sign out';
+            btn.addEventListener('click', async () => {
+              try { await api('/api/auth/logout', { method: 'POST' }); } catch {}
+              location.reload();
+            });
+            authArea.appendChild(span);
+            authArea.appendChild(btn);
+          }
+
+          function escapeHtml(s) {
+            return String(s)
+              .replaceAll('&', '&amp;')
+              .replaceAll('<', '&lt;')
+              .replaceAll('>', '&gt;')
+              .replaceAll('"', '&quot;')
+              .replaceAll("'", '&#039;');
+          }
+
+          function normalizeLang(lang) {
+            if (!lang) return '';
+            let id = String(lang).trim().toLowerCase();
+            id = id.replace(/^language-/, '').replace(/[^a-z0-9+#-]+/g, '');
+            const map = {
+              js: 'javascript', mjs: 'javascript', cjs: 'javascript', node: 'javascript',
+              ts: 'typescript', tsx: 'typescript', jsx: 'javascript',
+              cplusplus: 'cpp', 'c++': 'cpp', cpp: 'cpp',
+              csharp: 'csharp', 'c#': 'csharp', cs: 'csharp',
+              sh: 'bash', zsh: 'bash', shell: 'bash', console: 'bash',
+              ps1: 'powershell', pwsh: 'powershell',
+              py: 'python',
+              rb: 'ruby',
+              tf: 'hcl', terraform: 'hcl',
+              yml: 'yaml',
+            };
+            return map[id] || id;
+          }
+
+          function renderDocuments() {
+            if (!tabList) return;
+            tabList.innerHTML = '';
+            const query = searchText.trim().toLowerCase();
+            const filtered = docs.filter(doc => {
+              if (!query) return true;
+              return `${doc.title || ''}\n${doc.content || ''}`.toLowerCase().includes(query);
+            });
+            filtered.forEach(doc => {
+              const button = document.createElement('button');
+              button.className = 'eu-doc-item' + (doc.id === active ? ' active' : '');
+              button.dataset.id = doc.id;
+              button.type = 'button';
+              button.setAttribute('role', 'tab');
+              button.setAttribute('aria-selected', String(doc.id === active));
+              button.innerHTML = [
+                '<span class="eu-doc-icon"><svg class="eu-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M9 13h6"/><path d="M9 17h4"/></svg></span>',
+                `<span><span class="eu-doc-title">${escapeHtml(doc.title || 'Untitled')}</span><span class="eu-doc-subtitle">${escapeHtml(excerpt(doc.content || ''))}</span></span>`,
+                '<span class="eu-more-dots">...</span>',
+              ].join('');
+              button.addEventListener('click', () => {
+                switchToDoc(doc.id).catch(() => {});
+              });
+              button.addEventListener('dblclick', (e) => {
+                e.preventDefault();
+                if (active !== doc.id) {
+                  switchToDoc(doc.id).then(renameDoc).catch(() => {});
+                } else {
+                  renameDoc();
+                }
+              });
+              tabList.appendChild(button);
+            });
+            if (!filtered.length) {
+              const empty = document.createElement('div');
+              empty.className = 'eu-muted';
+              empty.textContent = 'No documents match this search.';
+              tabList.appendChild(empty);
+            }
+          }
+
+          function renderInfo() {
+            const doc = getActive();
+            const content = input.value || '';
+            const words = wordCount(content);
+            $('infoTitle').textContent = doc?.title || 'Untitled';
+            $('infoSource').textContent = MODE === 'account' ? 'Account storage' : 'Local only';
+            $('infoCreated').textContent = formatDate(doc?.created_at);
+            $('infoUpdated').textContent = formatDate(doc?.updated_at);
+            $('infoSize').textContent = formatBytes(byteSize(content));
+            $('infoWords').textContent = words.toLocaleString();
+            $('infoReadingTime').textContent = `~${readingMinutes(words)} min`;
+            $('readerMeta').textContent = formatRange(doc);
+            bookmarkButton?.classList.toggle('active', !!doc?.bookmarked);
+          }
+
+          function renderPE(src) {
+            if (!src) return '';
+            let text = src;
+
+            const codeStore = [];
+            text = text.replace(/\[code(?:=([^\]]+))?\]([\s\S]*?)\[\/code\]/gi, (m, langParam, body) => {
+              let lang = null, noHighlight = false, forceAuto = false;
+              if (langParam) {
+                let p = String(langParam).trim();
+                if (p.includes('*')) { noHighlight = true; p = p.replace('*', ''); }
+                if (p.includes('?')) { forceAuto = true; p = p.replace('?', ''); }
+                p = p.trim();
+                if (p) lang = normalizeLang(p.toLowerCase());
               }
-              const isOrdered = !!type;
-              let typeAttr = '';
-              if (type && /^(?:1|a|A|i|I)$/.test(type)) typeAttr = ` type="${type}"`;
-              const startAttr = (start && /^\d+$/.test(start)) ? ` start="${start}"` : '';
-              if (isOrdered) {
-                return `<ol${typeAttr}${startAttr}>` + items.map(it => `<li>${it}<\/li>`).join('') + `<\/ol>`;
+              const idx = codeStore.push({ lang, noHighlight, forceAuto, code: body }) - 1;
+              return `\uE000CODE${idx}\uE000`;
+            });
+
+            const replacements = [
+              { re: /\[b\]([\s\S]*?)\[\/b\]/gi, out: '<strong>$1</strong>' },
+              { re: /\[i\]([\s\S]*?)\[\/i\]/gi, out: '<em>$1</em>' },
+              { re: /\[s\]([\s\S]*?)\[\/s\]/gi, out: '<del>$1</del>' },
+              { re: /\[sup\]([\s\S]*?)\[\/sup\]/gi, out: '<sup>$1</sup>' },
+              { re: /\[sub\]([\s\S]*?)\[\/sub\]/gi, out: '<sub>$1</sub>' },
+              { re: /\[r\]([\s\S]*?)\[\/r\]/gi, out: '<span class="pe-red">$1</span>' },
+              { re: /\[g\]([\s\S]*?)\[\/g\]/gi, out: '<span class="pe-green">$1</span>' },
+              { re: /\[h1\]([\s\S]*?)\[\/h1\]/gi, out: '<h1>$1<\/h1>' },
+              { re: /\[h2\]([\s\S]*?)\[\/h2\]/gi, out: '<h2>$1<\/h2>' },
+              { re: /\[center\]([\s\S]*?)\[\/center\]/gi, out: '<div class="pe-center">$1<\/div>' },
+              { re: /\[right\]([\s\S]*?)\[\/right\]/gi, out: '<div class="pe-right">$1<\/div>' },
+              { re: /\[img\]([\s\S]*?)\[\/img\]/gi, out: '<img src="$1" alt="image" />' },
+              { re: /\[url\]([\s\S]*?)\[\/url\]/gi, out: '<a href="$1" target="_blank" rel="noopener noreferrer">$1<\/a>' },
+              { re: /\[url=([^\]]+)\]([\s\S]*?)\[\/url\]/gi, out: '<a href="$1" target="_blank" rel="noopener noreferrer">$2<\/a>' },
+              { re: /\[hide\]([\s\S]*?)\[\/hide\]/gi, out: '<span class="pe-hide" tabindex="0">$1<\/span>' },
+            ];
+            replacements.forEach(r => { text = text.replace(r.re, r.out); });
+
+            text = text.replace(/\[quote(?:=([^\]]+))?\]([\s\S]*?)\[\/quote\]/gi, (m, who, body) => {
+              let head = '';
+              if (who) {
+                let w = String(who).trim();
+                w = w.replace(/^"|"$/g, '');
+                if (/^\d+$/.test(w)) head = `<div class="pe-quote-head">User ${w} said<\/div>`;
+                else head = `<div class="pe-quote-head">${escapeHtml(w)} said<\/div>`;
               }
-              return `<ul>` + items.map(it => `<li>${it}<\/li>`).join('') + `<\/ul>`;
+              return `<div class="pe-quote">${head}<div>${body}<\/div><\/div>`;
             });
-          }
-          text = replaceLists(text);
 
-          // Auto-link bare URLs
-          text = text.replace(/(^|\s)(https?:\/\/[^\s<>]+)(?=\s|$)/g, (m, pre, url) => `${pre}<a href="${url}" target="_blank" rel="noopener noreferrer">${url}<\/a>`);
+            text = text.replace(/\[collapse(?:=([^\]]+))?\]([\s\S]*?)\[\/collapse\]/gi, (m, title, body) => {
+              const t = title ? escapeHtml(String(title)) : 'Details';
+              return `<details class="pe-collapse"><summary>${t}<\/summary><div class="pe-collapse-body">${body}<\/div><\/details>`;
+            });
 
-          // Convert remaining newlines to <br> outside code blocks to preserve layout
-          text = text.replace(/\r?\n/g, '<br>');
-
-          // Restore code blocks (keeps original newlines inside <pre>)
-          text = text.replace(/\uE000CODE(\d+)\uE000/g, (m, i) => {
-            const idx = Number(i);
-            const c = codeStore[idx];
-            if (!c) return '';
-            // c.code already contains escaped entities because we escaped the whole input earlier.
-            // Avoid double-escaping so <, >, & render correctly in code blocks.
-            const codeHtml = c.code;
-            const label = c.lang ? c.lang : (c.forceAuto ? 'auto' : 'code');
-            const langClass = c.lang ? ` language-${c.lang}` : '';
-            const pre = `<pre><code class="hljs${c.noHighlight ? '' : langClass}">${codeHtml}<\/code><\/pre>`;
-            return `<details class="pe-collapse" open><summary>Code (${escapeHtml(label)})<\/summary><div class="pe-collapse-body">${pre}<\/div><\/details>`;
-          });
-
-          return text;
-        }
-
-        function startInlineRename(docId) {
-          if (!tabList) return;
-          const doc = docs.find(d => d.id === docId);
-          const btn = tabList.querySelector(`button.tab[data-id="${docId}"]`);
-          if (!doc || !btn) return;
-          if (btn.querySelector('input.tab-rename')) return;
-          const original = doc.title || 'Untitled';
-          const inputEl = document.createElement('input');
-          inputEl.type = 'text';
-          inputEl.className = 'tab-rename';
-          inputEl.value = original;
-          btn.textContent = '';
-          btn.appendChild(inputEl);
-          btn.disabled = true;
-          inputEl.focus();
-          inputEl.select();
-          const finish = (commit) => {
-            if (!btn.disabled) return;
-            btn.disabled = false;
-            inputEl.blur();
-            const val = (commit ? inputEl.value : original).trim();
-            if (commit) {
-              doc.title = val || original;
-              persistRename(doc).catch(() => {});
+            function replaceLists(str) {
+              return str.replace(/\[list(?:=([^\]@\n]+)?(?:@([0-9]+))?)?\]([\s\S]*?)\[\/list\]/gi, (m, type, start, body) => {
+                const items = [];
+                const reItem = /\[\*\](.*?)(?=(?:\n\[\*\])|$)/gs;
+                let match; let content = body.trim();
+                while ((match = reItem.exec(content)) !== null) {
+                  items.push(match[1].trim());
+                }
+                const isOrdered = !!type;
+                let typeAttr = '';
+                if (type && /^(?:1|a|A|i|I)$/.test(type)) typeAttr = ` type="${type}"`;
+                const startAttr = (start && /^\d+$/.test(start)) ? ` start="${start}"` : '';
+                if (isOrdered) {
+                  return `<ol${typeAttr}${startAttr}>` + items.map(it => `<li>${it}<\/li>`).join('') + `<\/ol>`;
+                }
+                return `<ul>` + items.map(it => `<li>${it}<\/li>`).join('') + `<\/ul>`;
+              });
             }
-            renderTabs();
-            const newBtnRef = tabList.querySelector(`button.tab[data-id="${docId}"]`);
-            if (newBtnRef) newBtnRef.focus();
-          };
-          inputEl.addEventListener('keydown', (e) => {
-            e.stopPropagation();
-            if (e.key === 'Enter') { e.preventDefault(); finish(true); }
-            else if (e.key === 'Escape') { e.preventDefault(); finish(false); }
-          });
-          inputEl.addEventListener('blur', () => finish(true), { once: true });
-        }
+            text = replaceLists(text);
 
-        function renderTabs() {
-          if (!tabList) return;
-          tabList.innerHTML = '';
-          docs.forEach(doc => {
-            const b = document.createElement('button');
-            b.className = 'tab' + (doc.id === active ? ' active' : '');
-            b.textContent = doc.title || 'Untitled';
-            b.dataset.id = doc.id;
-            b.setAttribute('role', 'tab');
-            b.setAttribute('aria-selected', String(doc.id === active));
-            b.addEventListener('click', () => {
-              switchToDoc(doc.id).catch(() => {});
+            text = text.replace(/(^|\s)(https?:\/\/[^\s<>]+)(?=\s|$)/g, (m, pre, url) => `${pre}<a href="${url}" target="_blank" rel="noopener noreferrer">${url}<\/a>`);
+            text = text.replace(/\r?\n/g, '<br>');
+            text = text.replace(/\uE000CODE(\d+)\uE000/g, (m, i) => {
+              const idx = Number(i);
+              const c = codeStore[idx];
+              if (!c) return '';
+              const codeHtml = c.code;
+              const label = c.lang ? c.lang : (c.forceAuto ? 'auto' : 'code');
+              const langClass = c.lang ? ` language-${c.lang}` : '';
+              const pre = `<pre><code class="hljs${c.noHighlight ? '' : langClass}">${codeHtml}<\/code><\/pre>`;
+              return `<details class="pe-collapse" open><summary>Code (${escapeHtml(label)})<\/summary><div class="pe-collapse-body">${pre}<\/div><\/details>`;
             });
-            b.addEventListener('dblclick', (e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (active !== doc.id) return switchToDoc(doc.id).then(() => setTimeout(() => startInlineRename(doc.id), 0));
-              setTimeout(() => startInlineRename(doc.id), 0);
-            });
-            tabList.appendChild(b);
-          });
-        }
 
-        async function newDoc() {
-          if (MODE === 'account') {
-            const count = docs.length + 1;
-            const res = await api('/api/pages/create', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ tool: TOOL, title: `Doc ${count}`, content: '' }),
-            });
-            docs.unshift({ id: res.id, title: `Doc ${count}`, content: '' });
-            active = res.id;
-            localStorage.setItem(REMOTE_ACTIVE_KEY, active);
-            input.value = '';
-            renderTabs();
-            render();
-            return;
+            return text;
           }
-          const count = docs.length + 1;
-          const doc = { id: uid(), title: `Doc ${count}`, content: '' };
-          const current = getActive();
-          if (current) current.content = input.value;
-          docs.push(doc);
-          active = doc.id;
-          saveLocalState(docs, active);
-          input.value = '';
-          render();
-          renderTabs();
-        }
 
-        function renameDoc() {
-          const current = getActive();
-          if (!current) return;
-          renderTabs();
-          startInlineRename(current.id);
-        }
+          function render() {
+            const raw = input.value || '';
+            const preEscaped = raw.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+            const html = renderPE(preEscaped);
+            const safe = window.DOMPurify
+              ? window.DOMPurify.sanitize(html, { ADD_ATTR: ['target','rel','open','start','type','tabindex'], ADD_TAGS: ['details','summary'] })
+              : html;
+            preview.innerHTML = safe;
+            if (window.hljs) {
+              preview.querySelectorAll('pre code').forEach((el) => {
+                if (el.classList.contains('nohighlight')) return;
+                try {
+                  let given = '';
+                  for (const c of el.classList) {
+                    if (c.startsWith('language-')) {
+                      given = c.slice(9);
+                      break;
+                    }
+                  }
+                  const norm = normalizeLang(given);
+                  Array.from(el.classList).filter(c => c.startsWith('language-')).forEach(c => el.classList.remove(c));
+                  if (norm && window.hljs.getLanguage && window.hljs.getLanguage(norm)) el.classList.add('language-' + norm);
+                  el.classList.add('hljs');
+                  window.hljs.highlightElement(el);
+                } catch {}
+              });
+            }
+            if (window.MathJax && window.MathJax.typesetPromise) {
+              window.MathJax.typesetPromise([preview]).catch(() => {});
+            }
+            renderInfo();
+          }
 
-        async function deleteDoc() {
-          if (docs.length <= 1) { alert('At least one document must remain.'); return; }
-          const current = getActive();
-          if (!current) return;
-          const idx = docs.findIndex(d => d.id === current.id);
-          if (idx < 0) return;
-          if (MODE === 'account') {
-            await api('/api/pages/delete', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ id: current.id }),
-            });
-            docs.splice(idx, 1);
-            active = docs[Math.max(0, idx - 1)].id;
+          async function loadAccountDocs() {
+            const list = await api(`/api/pages/list?tool=${encodeURIComponent(TOOL)}`);
+            docs = (list || []).map(r => ({
+              id: r.id,
+              title: r.title,
+              content: null,
+              created_at: r.created_at || nowIso(),
+              updated_at: r.updated_at || r.created_at || nowIso(),
+              bookmarked: false,
+            })).map(normalizeDoc);
+            if (!docs.length) {
+              const created = await api('/api/pages/create', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ tool: TOOL, title: 'Welcome', content: input.value || DEFAULT_CONTENT }),
+              });
+              docs = [normalizeDoc({ id: created.id, title: 'Welcome', content: input.value || DEFAULT_CONTENT }, 0)];
+              active = created.id;
+              localStorage.setItem(REMOTE_ACTIVE_KEY, active);
+              return;
+            }
+            const wanted = localStorage.getItem(REMOTE_ACTIVE_KEY) || '';
+            active = docs.some(d => d.id === wanted) ? wanted : docs[0].id;
             localStorage.setItem(REMOTE_ACTIVE_KEY, active);
             await ensureLoaded(active);
             input.value = getActive().content || '';
-            render();
-            renderTabs();
-            return;
           }
-          docs.splice(idx, 1);
-          active = docs[Math.max(0, idx - 1)].id;
-          saveLocalState(docs, active);
-          input.value = getActive().content || '';
-          render();
-          renderTabs();
-        }
 
-        async function loadAccountDocs() {
-          const list = await api(`/api/pages/list?tool=${encodeURIComponent(TOOL)}`);
-          docs = (list || []).map(r => ({ id: r.id, title: r.title, content: null }));
-          if (!docs.length) {
-            const created = await api('/api/pages/create', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ tool: TOOL, title: 'Welcome', content: input.value || DEFAULT_CONTENT }),
-            });
-            docs = [{ id: created.id, title: 'Welcome', content: input.value || DEFAULT_CONTENT }];
-            active = created.id;
-            localStorage.setItem(REMOTE_ACTIVE_KEY, active);
-            return;
+          function loadLocalDocs() {
+            const st = loadLocalState();
+            docs = st.docs;
+            active = st.active;
+            if (!Array.isArray(docs) || docs.length === 0) {
+              docs = [normalizeDoc({ id: uid(), title: 'Welcome', content: input.value || DEFAULT_CONTENT }, 0)];
+              active = docs[0].id;
+              saveLocalState(docs, active);
+            }
+            const current = getActive();
+            active = current.id;
+            input.value = current.content || '';
           }
-          const wanted = localStorage.getItem(REMOTE_ACTIVE_KEY) || '';
-          active = docs.some(d => d.id === wanted) ? wanted : docs[0].id;
-          localStorage.setItem(REMOTE_ACTIVE_KEY, active);
-          await ensureLoaded(active);
-          input.value = getActive().content || '';
-        }
 
-        function loadLocalDocs() {
-          let st = loadLocalState();
-          docs = st.docs;
-          active = st.active;
-          if (!Array.isArray(docs) || docs.length === 0) {
-            docs = [{ id: uid(), title: 'Welcome', content: input.value || DEFAULT_CONTENT }];
-            active = docs[0].id;
-            saveLocalState(docs, active);
+          async function ensureLoaded(docId) {
+            const doc = docs.find(d => d.id === docId);
+            if (!doc || MODE !== 'account' || typeof doc.content === 'string') return;
+            const full = await api(`/api/pages/get?id=${encodeURIComponent(docId)}`);
+            doc.title = full.title || doc.title;
+            doc.content = full.content || '';
+            doc.created_at = full.created_at || doc.created_at;
+            doc.updated_at = full.updated_at || doc.updated_at;
           }
-          input.value = getActive().content || '';
-        }
 
-        async function ensureLoaded(docId) {
-          const doc = docs.find(d => d.id === docId);
-          if (!doc) return;
-          if (MODE !== 'account') return;
-          if (typeof doc.content === 'string') return;
-          const full = await api(`/api/pages/get?id=${encodeURIComponent(docId)}`);
-          doc.title = full.title || doc.title;
-          doc.content = full.content || '';
-        }
-
-        async function switchToDoc(docId) {
-          const current = getActive();
-          if (current) {
+          async function persistCurrent() {
+            const current = getActive();
+            if (!current) return;
             current.content = input.value;
+            current.updated_at = nowIso();
+            setSaveState('Saving...', true);
             if (MODE === 'account') {
-              api('/api/pages/update', {
+              await api('/api/pages/update', {
                 method: 'POST',
                 headers: { 'content-type': 'application/json' },
                 body: JSON.stringify({ id: current.id, content: current.content }),
-              }).catch(() => {});
+              });
             } else {
               saveLocalState(docs, active);
             }
+            setSaveState('Auto-saved', false);
+            renderDocuments();
+            renderInfo();
           }
-          active = docId;
-          if (MODE === 'account') localStorage.setItem(REMOTE_ACTIVE_KEY, active);
-          await ensureLoaded(active);
-          input.value = getActive().content || '';
-          render();
-          renderTabs();
-        }
 
-        async function persistRename(doc) {
-          if (MODE === 'account') {
-            await api('/api/pages/update', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              body: JSON.stringify({ id: doc.id, title: doc.title }),
-            });
-            return;
-          }
-          saveLocalState(docs, active);
-        }
-
-        if (newBtn) newBtn.addEventListener('click', newDoc);
-        if (renameBtn) renameBtn.addEventListener('click', renameDoc);
-        if (deleteBtn) deleteBtn.addEventListener('click', deleteDoc);
-
-        const render = () => {
-          const raw = input.value || '';
-          // Escape any HTML first, then convert BBCode to HTML
-          const preEscaped = raw.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
-          let html = renderPE(preEscaped);
-          // Sanitize
-          const safe = window.DOMPurify ? window.DOMPurify.sanitize(html, { ADD_ATTR: ['target','rel','open','start','type'], ADD_TAGS: ['details','summary'] }) : html;
-          preview.innerHTML = safe;
-          // Syntax highlight if available
-          if (window.hljs) {
-            preview.querySelectorAll('pre code').forEach((el) => {
-              if (el.classList.contains('nohighlight')) return;
-              try {
-                // Normalize language if present
-                let given = '';
-                for (const c of el.classList) { if (c.startsWith('language-')) { given = c.slice(9); break; } }
-                const norm = normalizeLang(given);
-                // Remove all language-* so we can add the normalized one or let auto-detect work
-                Array.from(el.classList).filter(c => c.startsWith('language-')).forEach(c => el.classList.remove(c));
-                if (norm && window.hljs.getLanguage && window.hljs.getLanguage(norm)) {
-                  el.classList.add('language-' + norm);
-                }
-                el.classList.add('hljs');
-                window.hljs.highlightElement(el);
-              } catch {}
-            });
-          }
-          // MathJax typeset
-          if (window.MathJax && window.MathJax.typesetPromise) {
-            window.MathJax.typesetPromise([preview]).catch(() => {});
-          }
-        };
-
-        // Render & wire events
-        let t;
-        input.addEventListener('input', () => {
-          render();
-          clearTimeout(t);
-          t = setTimeout(() => {
+          async function switchToDoc(docId) {
             const current = getActive();
             if (current) {
               current.content = input.value;
-              if (MODE === 'account') {
+              if (MODE === 'local') saveLocalState(docs, active);
+              else {
                 api('/api/pages/update', {
                   method: 'POST',
                   headers: { 'content-type': 'application/json' },
                   body: JSON.stringify({ id: current.id, content: current.content }),
                 }).catch(() => {});
-              } else {
-                saveLocalState(docs, active);
               }
             }
-          }, 450);
-        });
+            active = docId;
+            if (MODE === 'account') localStorage.setItem(REMOTE_ACTIVE_KEY, active);
+            await ensureLoaded(active);
+            input.value = getActive().content || '';
+            closeMoreMenu();
+            render();
+            renderDocuments();
+            setSaveState('Auto-saved', false);
+          }
 
-        const copyBtn = document.getElementById('copyHtml');
-        if (copyBtn) {
-          copyBtn.addEventListener('click', async () => {
+          async function newDoc() {
+            await persistCurrent().catch(() => {});
+            const count = docs.length + 1;
+            const title = `Doc ${count}`;
+            if (MODE === 'account') {
+              const res = await api('/api/pages/create', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ tool: TOOL, title, content: '' }),
+              });
+              docs.unshift(normalizeDoc({ id: res.id, title, content: '' }, 0));
+              active = res.id;
+              localStorage.setItem(REMOTE_ACTIVE_KEY, active);
+            } else {
+              const doc = normalizeDoc({ id: uid(), title, content: '' }, count - 1);
+              docs.push(doc);
+              active = doc.id;
+              saveLocalState(docs, active);
+            }
+            input.value = '';
+            render();
+            renderDocuments();
+            input.focus();
+          }
+
+          async function persistRename(doc) {
+            if (MODE === 'account') {
+              await api('/api/pages/update', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ id: doc.id, title: doc.title }),
+              });
+            } else {
+              saveLocalState(docs, active);
+            }
+          }
+
+          function renameDoc() {
+            const current = getActive();
+            if (!current) return;
+            const next = prompt('Rename document', current.title || 'Untitled');
+            if (next === null) return;
+            const title = next.trim() || current.title || 'Untitled';
+            current.title = title.slice(0, 200);
+            current.updated_at = nowIso();
+            persistRename(current).catch(() => {});
+            closeMoreMenu();
+            renderDocuments();
+            renderInfo();
+          }
+
+          async function deleteDoc() {
+            if (docs.length <= 1) {
+              alert('At least one document must remain.');
+              return;
+            }
+            const current = getActive();
+            if (!current || !confirm(`Delete "${current.title || 'Untitled'}"?`)) return;
+            const idx = docs.findIndex(d => d.id === current.id);
+            if (idx < 0) return;
+            if (MODE === 'account') {
+              await api('/api/pages/delete', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ id: current.id }),
+              });
+            }
+            docs.splice(idx, 1);
+            active = docs[Math.max(0, idx - 1)].id;
+            if (MODE === 'account') localStorage.setItem(REMOTE_ACTIVE_KEY, active);
+            else saveLocalState(docs, active);
+            await ensureLoaded(active);
+            input.value = getActive().content || '';
+            closeMoreMenu();
+            render();
+            renderDocuments();
+          }
+
+          function exportHtml() {
+            const current = getActive();
+            const title = current?.title || 'Euler Preview Export';
+            const html = [
+              '<!doctype html><html lang="en"><head><meta charset="utf-8">',
+              `<title>${escapeHtml(title)}</title>`,
+              '<meta name="viewport" content="width=device-width, initial-scale=1">',
+              '<style>body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;line-height:1.58;max-width:920px;margin:48px auto;padding:0 24px;color:#192338}pre{overflow:auto;padding:14px;background:#f4f6f8;border-radius:8px}.pe-quote{border-left:4px solid #bcd0ff;padding:10px 14px;background:#f6f8fb}.pe-collapse{border:1px solid #d0d5dd;border-radius:8px;margin:18px 0}.pe-collapse summary{padding:10px 12px;background:#f4f6f8;font-weight:700}.pe-collapse-body{padding:12px 14px}img{max-width:100%}</style>',
+              '</head><body>',
+              preview.innerHTML,
+              '</body></html>',
+            ].join('');
+            const blob = new Blob([html], { type: 'text/html' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `${slugify(title)}.html`;
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            URL.revokeObjectURL(url);
+          }
+
+          function slugify(text) {
+            return String(text || 'euler-preview')
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-|-$/g, '') || 'euler-preview';
+          }
+
+          async function copyRenderedHtml() {
+            const old = copyBtn?.textContent;
             try {
               await navigator.clipboard.writeText(preview.innerHTML);
-              const old = copyBtn.textContent;
-              copyBtn.textContent = 'Copied!';
-              setTimeout(() => { copyBtn.textContent = old || 'Copy HTML'; }, 1200);
+              if (copyBtn) copyBtn.textContent = 'Copied';
             } catch {
               const tmp = document.createElement('textarea');
               tmp.value = preview.innerHTML;
               document.body.appendChild(tmp);
               tmp.select();
               document.execCommand('copy');
-              document.body.removeChild(tmp);
+              tmp.remove();
+              if (copyBtn) copyBtn.textContent = 'Copied';
+            }
+            if (copyBtn) setTimeout(() => { copyBtn.textContent = old || 'Copy HTML'; }, 1200);
+          }
+
+          async function shareSource() {
+            const current = getActive();
+            const data = { title: current?.title || 'Euler preview', text: input.value };
+            if (navigator.share && navigator.canShare && navigator.canShare(data)) {
+              await navigator.share(data).catch(() => {});
+              return;
+            }
+            await navigator.clipboard?.writeText(input.value).catch(() => {});
+          }
+
+          function closeMoreMenu() {
+            moreMenu?.classList.remove('open');
+            moreButton?.setAttribute('aria-expanded', 'false');
+          }
+
+          function toggleBookmark() {
+            const current = getActive();
+            if (!current) return;
+            current.bookmarked = !current.bookmarked;
+            if (MODE === 'local') saveLocalState(docs, active);
+            renderInfo();
+          }
+
+          input.addEventListener('input', () => {
+            render();
+            setSaveState('Saving...', true);
+            clearTimeout(saveTimer);
+            saveTimer = setTimeout(() => {
+              persistCurrent().catch(() => setSaveState('Save failed', false));
+            }, 450);
+          });
+          newBtn?.addEventListener('click', () => newDoc().catch(() => {}));
+          renameBtn?.addEventListener('click', renameDoc);
+          deleteBtn?.addEventListener('click', () => deleteDoc().catch(() => {}));
+          copyBtn?.addEventListener('click', copyRenderedHtml);
+          exportHtmlBtn?.addEventListener('click', exportHtml);
+          exportPdfBtn?.addEventListener('click', () => window.print());
+          printButton?.addEventListener('click', () => window.print());
+          bookmarkButton?.addEventListener('click', toggleBookmark);
+          shareButton?.addEventListener('click', () => shareSource().catch(() => {}));
+          helpButton?.addEventListener('click', () => alert('Split View keeps the raw Euler forum source editor open. Full Width hides the editor and shows the rendered preview.'));
+          splitView?.addEventListener('click', () => setView('split'));
+          fullView?.addEventListener('click', () => setView('full'));
+          moreButton?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const open = !moreMenu?.classList.contains('open');
+            moreMenu?.classList.toggle('open', open);
+            moreButton.setAttribute('aria-expanded', String(open));
+          });
+          document.addEventListener('click', (e) => {
+            if (!moreMenu?.contains(e.target) && e.target !== moreButton) closeMoreMenu();
+          });
+          docSearch?.addEventListener('input', () => {
+            searchText = docSearch.value || '';
+            renderDocuments();
+          });
+          showAllDocs?.addEventListener('click', () => {
+            searchText = '';
+            if (docSearch) docSearch.value = '';
+            renderDocuments();
+          });
+          document.addEventListener('keydown', (e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+              e.preventDefault();
+              docSearch?.focus();
+              docSearch?.select();
             }
           });
+          decreaseFont?.addEventListener('click', () => {
+            readerSettings.fontSize = Math.max(12, Number(readerSettings.fontSize) - 1);
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+          increaseFont?.addEventListener('click', () => {
+            readerSettings.fontSize = Math.min(22, Number(readerSettings.fontSize) + 1);
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+          lineHeightSelect?.addEventListener('change', () => {
+            readerSettings.lineHeight = lineHeightSelect.value;
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+          widthSelect?.addEventListener('change', () => {
+            readerSettings.width = widthSelect.value;
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+          typeSelect?.addEventListener('change', () => {
+            readerSettings.type = typeSelect.value;
+            applyReaderSettings();
+            saveReaderSettings();
+          });
+
+          (async () => {
+            applyReaderSettings();
+            await refreshAuth();
+            if (MODE === 'account') await loadAccountDocs();
+            else loadLocalDocs();
+            render();
+            renderDocuments();
+            setSaveState('Auto-saved', false);
+          })();
         }
 
-        // Theme is owned by `public/shared/toolkit.js`.
-
-        (async () => {
-          await refreshAuth();
-          if (MODE === 'account') await loadAccountDocs();
-          else loadLocalDocs();
-          renderTabs();
-          render();
-        })();
-        }
         if (document.readyState === 'loading') {
           document.addEventListener('DOMContentLoaded', boot);
         } else {
@@ -663,4 +1627,4 @@ Hidden: [hide]Spoiler text[/hide], colors: [r]red[/r] and [g]green[/g].
       })();
     </script>
   </body>
-  </html>
+</html>


### PR DESCRIPTION
## Summary
- Redesigns the Euler Preview tool with the same document-reader UI pattern used by the updated Markdown Viewer.
- Keeps raw Project Euler forum source editable in Split View while Full Width focuses on the rendered preview.

## Changes
- Rebuilds `public/euler.html` with a document sidebar, search, document info, split/full view controls, reading settings, and export/share actions.
- Preserves BBCode conversion, TeX rendering, DOMPurify sanitization, syntax highlighting, and local/account document persistence.
- Keeps account-backed documents lazy-loaded correctly so saved raw Euler source remains editable after selection.

## Testing
- `npm test`
- Inline Euler page scripts syntax-checked with Node.
- Verified `/euler` served the updated layout locally with Wrangler.
