### PR TITLE
[codex] Add completed todo cleanup

### DIFF
--- a/public/todo.html
+++ b/public/todo.html
@@ -319,6 +319,16 @@
             background: rgba(255, 255, 255, 0.05);
         }
 
+        .btn:disabled {
+            cursor: not-allowed;
+            opacity: 0.55;
+        }
+
+        .btn:disabled:hover {
+            background: transparent;
+            color: inherit;
+        }
+
         .btn.primary {
             background: var(--accent-gradient);
             border-color: var(--accent);
@@ -346,6 +356,11 @@
         .btn.danger:hover {
             background: var(--danger);
             color: white;
+        }
+
+        .btn.danger:disabled:hover {
+            background: var(--danger-soft);
+            color: var(--danger);
         }
 
         .btn.sm {
@@ -882,6 +897,7 @@
                         <option value="finance">💰 Finance</option>
                         <option value="other">📌 Other</option>
                     </select>
+                    <button id="deleteCompletedBtn" class="btn danger sm" disabled>Delete Completed</button>
                     <button id="refreshBtn" class="btn ghost sm">Refresh</button>
                 </div>
             </div>
@@ -1006,6 +1022,14 @@
             qs('#statPending').textContent = pending;
             qs('#statCompleted').textContent = completed;
             qs('#statHigh').textContent = high;
+
+            const deleteCompletedBtn = qs('#deleteCompletedBtn');
+            if (deleteCompletedBtn) {
+                deleteCompletedBtn.disabled = completed === 0;
+                deleteCompletedBtn.title = completed === 0
+                    ? 'No completed tasks to delete'
+                    : `Delete ${completed} completed ${completed === 1 ? 'task' : 'tasks'}`;
+            }
         }
 
         function formatDueDate(dueDateStr) {
@@ -1069,6 +1093,7 @@
             }
 
             list.innerHTML = '';
+            updateStats();
 
             if (filtered.length === 0) {
                 const noFilters = filterStatus === 'all' && filterPriority === 'all' && filterCategory === 'all';
@@ -1119,8 +1144,6 @@
 
                 list.appendChild(item);
             });
-
-            updateStats();
         }
 
         async function loadTodos() {
@@ -1191,6 +1214,27 @@
                 loadTodos();
             } catch (e) {
                 alert('Failed to delete task: ' + e.message);
+            }
+        }
+
+        async function deleteCompletedTodos() {
+            const completed = TODOS.filter(t => t.completed).length;
+            if (completed === 0) return;
+            const label = `${completed} completed ${completed === 1 ? 'task' : 'tasks'}`;
+            if (!confirm(`Delete ${label}? This cannot be undone.`)) return;
+
+            const button = qs('#deleteCompletedBtn');
+            if (button) button.disabled = true;
+            try {
+                await api('/api/todo/delete-completed', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/json' }
+                });
+                await loadTodos();
+            } catch (e) {
+                alert('Failed to delete completed tasks: ' + e.message);
+            } finally {
+                updateStats();
             }
         }
 
@@ -1303,6 +1347,7 @@
         });
 
         qs('#refreshBtn').addEventListener('click', loadTodos);
+        qs('#deleteCompletedBtn').addEventListener('click', deleteCompletedTodos);
         qs('#filterStatus').addEventListener('change', renderTodos);
         qs('#filterPriority').addEventListener('change', renderTodos);
         qs('#filterCategory').addEventListener('change', renderTodos);

--- a/src/internal-test.ts
+++ b/src/internal-test.ts
@@ -33,6 +33,21 @@ async function ensureSchema(env: Bindings): Promise<void> {
     )
   `).run();
   await env.DB.prepare(`
+    CREATE TABLE IF NOT EXISTS todos (
+      id TEXT PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      description TEXT,
+      completed INTEGER NOT NULL DEFAULT 0,
+      priority TEXT NOT NULL CHECK (priority IN ('low','medium','high')) DEFAULT 'medium',
+      category TEXT DEFAULT 'personal',
+      due_date TEXT,
+      created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+      updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+    )
+  `).run();
+  await env.DB.prepare('CREATE INDEX IF NOT EXISTS idx_todos_user_completed ON todos(user_id, completed)').run();
+  await env.DB.prepare(`
     CREATE TABLE IF NOT EXISTS boards (
       id TEXT PRIMARY KEY,
       user_id TEXT NOT NULL,

--- a/src/todo.ts
+++ b/src/todo.ts
@@ -154,6 +154,15 @@ async function deleteTodo(request: Request, env: Bindings, userId: string): Prom
     return json({ ok: true });
 }
 
+async function deleteCompletedTodos(env: Bindings, userId: string): Promise<Response> {
+    const row = (await env.DB.prepare('SELECT COUNT(*) AS count FROM todos WHERE user_id = ? AND completed = 1')
+        .bind(userId)
+        .first()) as { count?: number } | null;
+    const deleted = Number(row?.count || 0);
+    await env.DB.prepare('DELETE FROM todos WHERE user_id = ? AND completed = 1').bind(userId).run();
+    return json({ ok: true, deleted });
+}
+
 async function toggleTodo(request: Request, env: Bindings, userId: string): Promise<Response> {
     const body = await readJson<{ id?: string }>(request);
     const id = (body.id || '').toString();
@@ -219,6 +228,12 @@ export async function handleTodoApi(
         const user = await requireUser(request, env);
         if (user instanceof Response) return user;
         return deleteTodo(request, env, (user as any).id);
+    }
+
+    if (path === '/api/todo/delete-completed' && request.method === 'POST') {
+        const user = await requireUser(request, env);
+        if (user instanceof Response) return user;
+        return deleteCompletedTodos(env, (user as any).id);
     }
 
     if (path === '/api/todo/toggle' && request.method === 'POST') {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -309,6 +309,7 @@ describe('Pretty routes and Pages API', () => {
 		expect(response.headers.get('content-type')).toContain('text/html');
 		const body = await response.text();
 		expect(body).toContain('<title>To-Do List</title>');
+		expect(body).toContain('id="deleteCompletedBtn"');
 	});
 
 	it('serves boards at /boards (unit)', async () => {
@@ -339,6 +340,93 @@ describe('Pretty routes and Pages API', () => {
 		const response = await worker.fetch(request, env, ctx);
 		await waitOnExecutionContext(ctx);
 		expect(response.status).toBe(401);
+	});
+
+	it('deletes completed todos without touching pending or other users', async () => {
+		(env as any).INTERNAL_TEST_KEY = 'k';
+
+		const seedUser = async (email: string) => {
+			const request = new IncomingRequest('http://example.com/api/_internal/seed', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json', 'x-internal-key': 'k' },
+				body: JSON.stringify({ email, name: email }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+			const seeded = await response.json<any>();
+			return String(seeded.token || '');
+		};
+
+		const createTodo = async (token: string, title: string) => {
+			const request = new IncomingRequest('http://example.com/api/todo/create', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json', cookie: `wt_session=${token}` },
+				body: JSON.stringify({ title }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+			return response.json<any>();
+		};
+
+		const toggleTodo = async (token: string, id: string) => {
+			const request = new IncomingRequest('http://example.com/api/todo/toggle', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json', cookie: `wt_session=${token}` },
+				body: JSON.stringify({ id }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+			const body = await response.json<any>();
+			expect(body.completed).toBe(true);
+		};
+
+		const listTodos = async (token: string) => {
+			const request = new IncomingRequest('http://example.com/api/todo/list', {
+				headers: { cookie: `wt_session=${token}` },
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+			return response.json<any[]>();
+		};
+
+		const tokenOne = await seedUser('todo-delete-one@example.com');
+		const tokenTwo = await seedUser('todo-delete-two@example.com');
+
+		const pending = await createTodo(tokenOne, 'Keep pending');
+		const completedOne = await createTodo(tokenOne, 'Delete completed one');
+		const completedTwo = await createTodo(tokenOne, 'Delete completed two');
+		const otherCompleted = await createTodo(tokenTwo, 'Other user completed');
+
+		await toggleTodo(tokenOne, completedOne.id);
+		await toggleTodo(tokenOne, completedTwo.id);
+		await toggleTodo(tokenTwo, otherCompleted.id);
+
+		const deleteReq = new IncomingRequest('http://example.com/api/todo/delete-completed', {
+			method: 'POST',
+			headers: { cookie: `wt_session=${tokenOne}` },
+		});
+		const deleteCtx = createExecutionContext();
+		const deleteRes = await worker.fetch(deleteReq, env, deleteCtx);
+		await waitOnExecutionContext(deleteCtx);
+		expect(deleteRes.status).toBe(200);
+		const deleted = await deleteRes.json<any>();
+		expect(deleted).toEqual({ ok: true, deleted: 2 });
+
+		const remainingForOne = await listTodos(tokenOne);
+		expect(remainingForOne.map((todo) => todo.id)).toEqual([pending.id]);
+		expect(remainingForOne[0].completed).toBe(0);
+
+		const remainingForTwo = await listTodos(tokenTwo);
+		expect(remainingForTwo.map((todo) => todo.id)).toContain(otherCompleted.id);
+		expect(remainingForTwo.find((todo) => todo.id === otherCompleted.id)?.completed).toBe(1);
 	});
 
 	it('creates and fetches a markdown page (unit)', async () => {


### PR DESCRIPTION
## What changed

Adds a bulk cleanup path for the `/todo` tool so signed-in users can delete all completed tasks at once.

- Added `POST /api/todo/delete-completed`, scoped to the authenticated user.
- Added a `Delete Completed` button to the todo list toolbar, with disabled state and confirmation.
- Added regression coverage for the button render and user-scoped deletion behavior.
- Added the todo table to the internal test schema setup so todo API tests can seed users and tasks.

## Impact

Users can clear completed todo items without deleting pending tasks. The API deletion is constrained by `user_id` and `completed = 1`, so it does not affect pending tasks or other users' data.

## Validation

- `npm test -- --run test/index.spec.ts` passed: 32 tests.