### PR TITLE
Improve large text diff handling

### DIFF
--- a/public/diff.html
+++ b/public/diff.html
@@ -62,6 +62,7 @@
         display: flex;
         align-items: center;
         justify-content: space-between;
+        flex-wrap: wrap;
         gap: 10px;
         border-bottom: 1px solid var(--border);
         padding: 10px 12px;
@@ -96,8 +97,40 @@
 
       .controls {
         display: flex;
+        align-items: center;
         flex-wrap: wrap;
         gap: 10px;
+      }
+
+      .output-options {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+
+      .toggle-control,
+      .number-control {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        min-height: 34px;
+        color: var(--wt-fg);
+        font-size: 0.84rem;
+      }
+
+      .toggle-control input {
+        margin: 0;
+      }
+
+      .number-control input {
+        width: 4.5rem;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 6px 8px;
+        background: var(--wt-input);
+        color: inherit;
+        font: inherit;
       }
 
       .stats {
@@ -205,6 +238,16 @@
         font-weight: 600;
       }
 
+      .diff-row-gap {
+        background: rgba(127, 127, 127, 0.06);
+      }
+
+      .diff-row-gap .text,
+      .diff-row-gap .marker {
+        color: var(--muted);
+        font-style: italic;
+      }
+
       @media (max-width: 900px) {
         .editor-grid {
           grid-template-columns: 1fr;
@@ -257,6 +300,16 @@
             <button id="compareBtn" class="wt-btn wt-btn-primary" type="button">Compare</button>
             <button id="swapBtn" class="wt-btn" type="button">Swap</button>
             <button id="clearBtn" class="wt-btn wt-btn-ghost" type="button">Clear</button>
+            <div class="output-options" aria-label="Diff output options">
+              <label class="toggle-control" for="contextOnlyToggle">
+                <input id="contextOnlyToggle" type="checkbox" />
+                <span>Nearby changes</span>
+              </label>
+              <label class="number-control" for="contextLinesInput">
+                <span>Context</span>
+                <input id="contextLinesInput" type="number" min="0" max="200" step="1" value="3" />
+              </label>
+            </div>
           </div>
           <div class="stats">
             <span class="stat"><span class="stat-key">Added</span><span id="addedCount">0</span></span>
@@ -275,15 +328,21 @@
     <script>
       const STORAGE_ORIGINAL = 'wt_diff_original';
       const STORAGE_CHANGED = 'wt_diff_changed';
+      const STORAGE_CONTEXT_ONLY = 'wt_diff_context_only';
+      const STORAGE_CONTEXT_LINES = 'wt_diff_context_lines';
       const SOFT_LINE_LIMIT = 10000;
       const EXACT_DIFF_CELL_LIMIT = 4000000;
       const MAX_DIFF_RECURSION_DEPTH = 64;
+      const DEFAULT_CONTEXT_LINES = 3;
+      const MAX_CONTEXT_LINES = 200;
 
       const originalInput = document.getElementById('originalInput');
       const changedInput = document.getElementById('changedInput');
       const compareBtn = document.getElementById('compareBtn');
       const swapBtn = document.getElementById('swapBtn');
       const clearBtn = document.getElementById('clearBtn');
+      const contextOnlyToggle = document.getElementById('contextOnlyToggle');
+      const contextLinesInput = document.getElementById('contextLinesInput');
       const warningEl = document.getElementById('warning');
       const diffOutput = document.getElementById('diffOutput');
 
@@ -293,6 +352,7 @@
       const unchangedCount = document.getElementById('unchangedCount');
       const originalLinesEl = document.getElementById('originalLines');
       const changedLinesEl = document.getElementById('changedLines');
+      let currentGroups = null;
 
       function normalizeNewlines(text) {
         return String(text || '').replace(/\r\n?/g, '\n');
@@ -352,6 +412,36 @@
         const text = document.createElement('pre');
         text.className = 'text';
         text.textContent = item.line === '' ? ' ' : item.line;
+
+        row.append(left, right, marker, text);
+        return row;
+      }
+
+      function formatLineRange(firstLine, lastLine) {
+        return firstLine === lastLine ? String(firstLine) : `${firstLine}-${lastLine}`;
+      }
+
+      function createGapRow(items) {
+        const first = items[0];
+        const last = items[items.length - 1];
+        const row = document.createElement('div');
+        row.className = 'diff-row diff-row-gap';
+
+        const left = document.createElement('span');
+        left.className = 'ln';
+        left.textContent = formatLineRange(first.oldNo, last.oldNo);
+
+        const right = document.createElement('span');
+        right.className = 'ln';
+        right.textContent = formatLineRange(first.newNo, last.newNo);
+
+        const marker = document.createElement('span');
+        marker.className = 'marker';
+        marker.textContent = '...';
+
+        const text = document.createElement('pre');
+        text.className = 'text';
+        text.textContent = `${items.length} unchanged line${items.length === 1 ? '' : 's'} hidden`;
 
         row.append(left, right, marker, text);
         return row;
@@ -721,6 +811,54 @@
         return stats;
       }
 
+      function normalizeContextLines() {
+        const parsed = Number.parseInt(contextLinesInput.value, 10);
+        const value = Number.isFinite(parsed)
+          ? Math.min(Math.max(parsed, 0), MAX_CONTEXT_LINES)
+          : DEFAULT_CONTEXT_LINES;
+        contextLinesInput.value = String(value);
+        return value;
+      }
+
+      function appendEqualItems(fragment, items) {
+        for (const item of items) fragment.appendChild(createRow('equal', item, false));
+      }
+
+      function appendHiddenGap(fragment, items) {
+        if (items.length > 0) fragment.appendChild(createGapRow(items));
+      }
+
+      function appendChangeGroup(fragment, group) {
+        if (group.type === 'add') {
+          for (const item of group.items) fragment.appendChild(createRow('add', item, false));
+          return;
+        }
+
+        if (group.type === 'remove') {
+          for (const item of group.items) fragment.appendChild(createRow('remove', item, false));
+          return;
+        }
+
+        for (const item of group.removed) fragment.appendChild(createRow('remove', item, true));
+        for (const item of group.added) fragment.appendChild(createRow('add', item, true));
+      }
+
+      function appendContextEqualGroup(fragment, items, showAfterPreviousChange, showBeforeNextChange, contextLines) {
+        const leadingCount = showAfterPreviousChange ? Math.min(contextLines, items.length) : 0;
+        const trailingCount = showBeforeNextChange
+          ? Math.min(contextLines, items.length - leadingCount)
+          : 0;
+
+        if (leadingCount + trailingCount >= items.length) {
+          appendEqualItems(fragment, items);
+          return;
+        }
+
+        if (leadingCount > 0) appendEqualItems(fragment, items.slice(0, leadingCount));
+        appendHiddenGap(fragment, items.slice(leadingCount, items.length - trailingCount));
+        if (trailingCount > 0) appendEqualItems(fragment, items.slice(items.length - trailingCount));
+      }
+
       function renderDiff(groups) {
         diffOutput.innerHTML = '';
         if (groups.length === 0) {
@@ -728,26 +866,34 @@
           return;
         }
 
+        const contextOnly = contextOnlyToggle.checked;
+        const contextLines = normalizeContextLines();
+        const hasChangedLines = groups.some((group) => group.type !== 'equal');
+        if (contextOnly && !hasChangedLines) {
+          renderEmptyState('No changed lines to show.');
+          return;
+        }
+
         const fragment = document.createDocumentFragment();
 
-        for (const group of groups) {
+        for (let index = 0; index < groups.length; index++) {
+          const group = groups[index];
           if (group.type === 'equal') {
-            for (const item of group.items) fragment.appendChild(createRow('equal', item, false));
+            if (contextOnly) {
+              appendContextEqualGroup(
+                fragment,
+                group.items,
+                index > 0,
+                index < groups.length - 1,
+                contextLines,
+              );
+            } else {
+              appendEqualItems(fragment, group.items);
+            }
             continue;
           }
 
-          if (group.type === 'add') {
-            for (const item of group.items) fragment.appendChild(createRow('add', item, false));
-            continue;
-          }
-
-          if (group.type === 'remove') {
-            for (const item of group.items) fragment.appendChild(createRow('remove', item, false));
-            continue;
-          }
-
-          for (const item of group.removed) fragment.appendChild(createRow('remove', item, true));
-          for (const item of group.added) fragment.appendChild(createRow('add', item, true));
+          appendChangeGroup(fragment, group);
         }
 
         diffOutput.appendChild(fragment);
@@ -767,6 +913,15 @@
         }
       }
 
+      function saveOutputSettings() {
+        try {
+          localStorage.setItem(STORAGE_CONTEXT_ONLY, contextOnlyToggle.checked ? 'true' : 'false');
+          localStorage.setItem(STORAGE_CONTEXT_LINES, String(normalizeContextLines()));
+        } catch {
+          // Ignore localStorage failures.
+        }
+      }
+
       function loadInputs() {
         try {
           originalInput.value = localStorage.getItem(STORAGE_ORIGINAL) || '';
@@ -774,6 +929,19 @@
         } catch {
           originalInput.value = '';
           changedInput.value = '';
+        }
+      }
+
+      function loadOutputSettings() {
+        try {
+          contextOnlyToggle.checked = localStorage.getItem(STORAGE_CONTEXT_ONLY) === 'true';
+          const storedContext = Number.parseInt(localStorage.getItem(STORAGE_CONTEXT_LINES) || '', 10);
+          contextLinesInput.value = Number.isFinite(storedContext)
+            ? String(Math.min(Math.max(storedContext, 0), MAX_CONTEXT_LINES))
+            : String(DEFAULT_CONTEXT_LINES);
+        } catch {
+          contextOnlyToggle.checked = false;
+          contextLinesInput.value = String(DEFAULT_CONTEXT_LINES);
         }
       }
 
@@ -790,6 +958,7 @@
 
         if (originalLines.length === 0 && changedLines.length === 0) {
           setStats({ added: 0, removed: 0, changed: 0, unchanged: 0 });
+          currentGroups = null;
           renderEmptyState('Enter text in both panels, then click Compare.');
           return;
         }
@@ -803,12 +972,14 @@
 
         if (result.error) {
           setStats({ added: 0, removed: 0, changed: 0, unchanged: 0 });
+          currentGroups = null;
           renderEmptyState(result.error);
           return;
         }
 
         const groups = groupOperations(result.ops);
         const stats = summarize(groups);
+        currentGroups = groups;
         setStats(stats);
         renderDiff(groups);
       }
@@ -829,6 +1000,7 @@
         setWarning('');
         updateLineCounts();
         setStats({ added: 0, removed: 0, changed: 0, unchanged: 0 });
+        currentGroups = null;
         renderEmptyState('Enter text in both panels, then click Compare.');
       }
 
@@ -837,7 +1009,13 @@
         updateLineCounts();
       }
 
+      function onOutputOptionChange() {
+        saveOutputSettings();
+        if (currentGroups) renderDiff(currentGroups);
+      }
+
       loadInputs();
+      loadOutputSettings();
       updateLineCounts();
       setStats({ added: 0, removed: 0, changed: 0, unchanged: 0 });
       renderEmptyState('Enter text in both panels, then click Compare.');
@@ -845,6 +1023,8 @@
       compareBtn.addEventListener('click', compare);
       swapBtn.addEventListener('click', swapInputs);
       clearBtn.addEventListener('click', clearAll);
+      contextOnlyToggle.addEventListener('change', onOutputOptionChange);
+      contextLinesInput.addEventListener('input', onOutputOptionChange);
 
       originalInput.addEventListener('input', onInputChange);
       changedInput.addEventListener('input', onInputChange);

--- a/public/diff.html
+++ b/public/diff.html
@@ -276,7 +276,8 @@
       const STORAGE_ORIGINAL = 'wt_diff_original';
       const STORAGE_CHANGED = 'wt_diff_changed';
       const SOFT_LINE_LIMIT = 10000;
-      const HARD_CELL_LIMIT = 4000000;
+      const EXACT_DIFF_CELL_LIMIT = 4000000;
+      const MAX_DIFF_RECURSION_DEPTH = 64;
 
       const originalInput = document.getElementById('originalInput');
       const changedInput = document.getElementById('changedInput');
@@ -356,24 +357,40 @@
         return row;
       }
 
-      function buildLineDiff(originalLines, changedLines) {
-        const n = originalLines.length;
-        const m = changedLines.length;
-        const cellCount = (n + 1) * (m + 1);
-        if (cellCount > HARD_CELL_LIMIT) {
-          return {
-            error:
-              'Inputs are too large for in-browser diffing. Reduce the text size or compare in smaller sections.',
-          };
-        }
+      function appendEqual(ops, line, oldIndex, newIndex) {
+        ops.push({ type: 'equal', line, oldNo: oldIndex + 1, newNo: newIndex + 1 });
+      }
 
+      function appendAddRange(ops, changedLines, start, end) {
+        for (let index = start; index < end; index++) {
+          ops.push({ type: 'add', line: changedLines[index], oldNo: null, newNo: index + 1 });
+        }
+      }
+
+      function appendRemoveRange(ops, originalLines, start, end) {
+        for (let index = start; index < end; index++) {
+          ops.push({ type: 'remove', line: originalLines[index], oldNo: index + 1, newNo: null });
+        }
+      }
+
+      function appendGroupedChange(ops, originalLines, changedLines, oldStart, oldEnd, newStart, newEnd) {
+        appendRemoveRange(ops, originalLines, oldStart, oldEnd);
+        appendAddRange(ops, changedLines, newStart, newEnd);
+      }
+
+      function buildExactLineDiff(originalLines, changedLines, oldStart, oldEnd, newStart, newEnd) {
+        const n = oldEnd - oldStart;
+        const m = newEnd - newStart;
         const table = Array.from({ length: n + 1 }, () => new Uint32Array(m + 1));
+
         for (let i = 1; i <= n; i++) {
           for (let j = 1; j <= m; j++) {
-            if (originalLines[i - 1] === changedLines[j - 1]) {
+            if (originalLines[oldStart + i - 1] === changedLines[newStart + j - 1]) {
               table[i][j] = table[i - 1][j - 1] + 1;
             } else {
-              table[i][j] = Math.max(table[i - 1][j], table[i][j - 1]);
+              const removeScore = table[i - 1][j];
+              const addScore = table[i][j - 1];
+              table[i][j] = removeScore > addScore ? removeScore : addScore;
             }
           }
         }
@@ -383,25 +400,248 @@
         const ops = [];
 
         while (i > 0 || j > 0) {
-          if (i > 0 && j > 0 && originalLines[i - 1] === changedLines[j - 1]) {
-            ops.push({ type: 'equal', line: originalLines[i - 1], oldNo: i, newNo: j });
+          if (
+            i > 0 &&
+            j > 0 &&
+            originalLines[oldStart + i - 1] === changedLines[newStart + j - 1]
+          ) {
+            ops.push({
+              type: 'equal',
+              line: originalLines[oldStart + i - 1],
+              oldNo: oldStart + i,
+              newNo: newStart + j,
+            });
             i--;
             j--;
             continue;
           }
 
           if (j > 0 && (i === 0 || table[i][j - 1] >= table[i - 1][j])) {
-            ops.push({ type: 'add', line: changedLines[j - 1], oldNo: null, newNo: j });
+            ops.push({
+              type: 'add',
+              line: changedLines[newStart + j - 1],
+              oldNo: null,
+              newNo: newStart + j,
+            });
             j--;
             continue;
           }
 
-          ops.push({ type: 'remove', line: originalLines[i - 1], oldNo: i, newNo: null });
+          ops.push({
+            type: 'remove',
+            line: originalLines[oldStart + i - 1],
+            oldNo: oldStart + i,
+            newNo: null,
+          });
           i--;
         }
 
         ops.reverse();
-        return { ops };
+        return ops;
+      }
+
+      function findUniqueAnchors(originalLines, changedLines, oldStart, oldEnd, newStart, newEnd) {
+        const records = new Map();
+
+        for (let index = oldStart; index < oldEnd; index++) {
+          const line = originalLines[index];
+          let record = records.get(line);
+          if (!record) {
+            record = { oldCount: 0, newCount: 0, oldIndex: -1, newIndex: -1 };
+            records.set(line, record);
+          }
+
+          record.oldCount += 1;
+          record.oldIndex = record.oldCount === 1 ? index : -1;
+        }
+
+        for (let index = newStart; index < newEnd; index++) {
+          const record = records.get(changedLines[index]);
+          if (!record) continue;
+
+          record.newCount += 1;
+          record.newIndex = record.newCount === 1 ? index : -1;
+        }
+
+        const candidates = [];
+        for (const record of records.values()) {
+          if (record.oldCount === 1 && record.newCount === 1) {
+            candidates.push({ oldIndex: record.oldIndex, newIndex: record.newIndex });
+          }
+        }
+
+        candidates.sort((a, b) => a.oldIndex - b.oldIndex);
+        if (candidates.length <= 1) return candidates;
+
+        const previous = new Int32Array(candidates.length);
+        previous.fill(-1);
+        const tailIndexes = [];
+        const tailValues = [];
+
+        for (let index = 0; index < candidates.length; index++) {
+          const value = candidates[index].newIndex;
+          let low = 0;
+          let high = tailValues.length;
+
+          while (low < high) {
+            const mid = Math.floor((low + high) / 2);
+            if (tailValues[mid] < value) {
+              low = mid + 1;
+            } else {
+              high = mid;
+            }
+          }
+
+          if (low > 0) previous[index] = tailIndexes[low - 1];
+          tailValues[low] = value;
+          tailIndexes[low] = index;
+        }
+
+        const anchors = [];
+        let cursor = tailIndexes[tailIndexes.length - 1];
+        while (cursor >= 0) {
+          anchors.push(candidates[cursor]);
+          cursor = previous[cursor];
+        }
+
+        anchors.reverse();
+        return anchors;
+      }
+
+      function diffRange(originalLines, changedLines, oldStart, oldEnd, newStart, newEnd, ops, depth) {
+        while (
+          oldStart < oldEnd &&
+          newStart < newEnd &&
+          originalLines[oldStart] === changedLines[newStart]
+        ) {
+          appendEqual(ops, originalLines[oldStart], oldStart, newStart);
+          oldStart++;
+          newStart++;
+        }
+
+        let suffixCount = 0;
+        while (
+          oldStart < oldEnd - suffixCount &&
+          newStart < newEnd - suffixCount &&
+          originalLines[oldEnd - suffixCount - 1] === changedLines[newEnd - suffixCount - 1]
+        ) {
+          suffixCount++;
+        }
+
+        const trimmedOldEnd = oldEnd - suffixCount;
+        const trimmedNewEnd = newEnd - suffixCount;
+        let usedGroupedFallback = false;
+
+        if (oldStart === trimmedOldEnd) {
+          appendAddRange(ops, changedLines, newStart, trimmedNewEnd);
+        } else if (newStart === trimmedNewEnd) {
+          appendRemoveRange(ops, originalLines, oldStart, trimmedOldEnd);
+        } else {
+          const oldLength = trimmedOldEnd - oldStart;
+          const newLength = trimmedNewEnd - newStart;
+          const cellCount = (oldLength + 1) * (newLength + 1);
+
+          if (cellCount <= EXACT_DIFF_CELL_LIMIT) {
+            const exactOps = buildExactLineDiff(
+              originalLines,
+              changedLines,
+              oldStart,
+              trimmedOldEnd,
+              newStart,
+              trimmedNewEnd,
+            );
+            for (const op of exactOps) ops.push(op);
+          } else if (depth >= MAX_DIFF_RECURSION_DEPTH) {
+            appendGroupedChange(
+              ops,
+              originalLines,
+              changedLines,
+              oldStart,
+              trimmedOldEnd,
+              newStart,
+              trimmedNewEnd,
+            );
+            usedGroupedFallback = true;
+          } else {
+            const anchors = findUniqueAnchors(
+              originalLines,
+              changedLines,
+              oldStart,
+              trimmedOldEnd,
+              newStart,
+              trimmedNewEnd,
+            );
+
+            if (anchors.length === 0) {
+              appendGroupedChange(
+                ops,
+                originalLines,
+                changedLines,
+                oldStart,
+                trimmedOldEnd,
+                newStart,
+                trimmedNewEnd,
+              );
+              usedGroupedFallback = true;
+            } else {
+              let previousOld = oldStart;
+              let previousNew = newStart;
+
+              for (const anchor of anchors) {
+                usedGroupedFallback =
+                  diffRange(
+                    originalLines,
+                    changedLines,
+                    previousOld,
+                    anchor.oldIndex,
+                    previousNew,
+                    anchor.newIndex,
+                    ops,
+                    depth + 1,
+                  ) || usedGroupedFallback;
+                appendEqual(ops, originalLines[anchor.oldIndex], anchor.oldIndex, anchor.newIndex);
+                previousOld = anchor.oldIndex + 1;
+                previousNew = anchor.newIndex + 1;
+              }
+
+              usedGroupedFallback =
+                diffRange(
+                  originalLines,
+                  changedLines,
+                  previousOld,
+                  trimmedOldEnd,
+                  previousNew,
+                  trimmedNewEnd,
+                  ops,
+                  depth + 1,
+                ) || usedGroupedFallback;
+            }
+          }
+        }
+
+        for (let offset = 0; offset < suffixCount; offset++) {
+          const oldIndex = trimmedOldEnd + offset;
+          const newIndex = trimmedNewEnd + offset;
+          appendEqual(ops, originalLines[oldIndex], oldIndex, newIndex);
+        }
+
+        return usedGroupedFallback;
+      }
+
+      function buildLineDiff(originalLines, changedLines) {
+        const ops = [];
+        const grouped = diffRange(
+          originalLines,
+          changedLines,
+          0,
+          originalLines.length,
+          0,
+          changedLines.length,
+          ops,
+          0,
+        );
+
+        return { ops, grouped };
       }
 
       function groupOperations(ops) {
@@ -541,12 +781,11 @@
         const originalLines = toLines(originalInput.value);
         const changedLines = toLines(changedInput.value);
         const totalLines = originalLines.length + changedLines.length;
+        let warningMessage = '';
 
         setWarning('');
         if (totalLines > SOFT_LINE_LIMIT) {
-          setWarning(
-            `Large input detected (${totalLines} lines total). Comparison may be slower than usual.`,
-          );
+          warningMessage = `Large input detected (${totalLines} lines total). Comparison may be slower than usual.`;
         }
 
         if (originalLines.length === 0 && changedLines.length === 0) {
@@ -556,6 +795,12 @@
         }
 
         const result = buildLineDiff(originalLines, changedLines);
+        if (result.grouped) {
+          const groupedMessage = 'Some large changed sections were grouped to keep comparison responsive.';
+          warningMessage = warningMessage ? `${warningMessage} ${groupedMessage}` : groupedMessage;
+        }
+        setWarning(warningMessage);
+
         if (result.error) {
           setStats({ added: 0, removed: 0, changed: 0, unchanged: 0 });
           renderEmptyState(result.error);

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -50,6 +50,8 @@ describe('Tools index and Markdown viewer', () => {
 		expect(body).toContain('<title>Text Diff</title>');
 		expect(body).toContain('id="originalInput"');
 		expect(body).toContain('id="changedInput"');
+		expect(body).toContain('id="contextOnlyToggle"');
+		expect(body).toContain('id="contextLinesInput"');
 	});
 
 	it('serves format converter at /format-tools (unit)', async () => {


### PR DESCRIPTION
## Summary
- Allows /diff to compare large inputs without hitting the previous in-browser matrix limit.
- Adds an output mode for showing only changed lines with nearby unchanged context.

## Changes
- Replaces the global O(n*m) line-diff matrix with a range-based diff that trims shared edges and anchors on unique lines.
- Keeps exact LCS diffing for small changed ranges and groups only very large unmatched sections to stay responsive.
- Adds a Nearby changes toggle and configurable context-line count for collapsed diff output.
- Preserves the existing large-input warning as advisory instead of blocking the compare.

## Testing
- npm test
- Node smoke test for small changes, nearby-changes output with 1 and 0 context lines, 34,502-line similar inputs, and 34,502-line completely different inputs.